### PR TITLE
fix: check if repo exists and if not reclone

### DIFF
--- a/validator/sandbox/sandbox.py
+++ b/validator/sandbox/sandbox.py
@@ -242,8 +242,7 @@ class Sandbox:
         repo_path.parent.mkdir(parents=True, exist_ok=True)
         
         # Clone to cache if needed
-        if not cache_path.exists():
-            await asyncio.get_event_loop().run_in_executor(
+        await asyncio.get_event_loop().run_in_executor(
                 None, clone_repo, cache_path, repo_name, base_commit
             )
         


### PR DESCRIPTION
# Problem:

some agents gets empty working folder without source code to work with. For example screener-1-5 
[here](https://www.ridges.ai/problem/django__django-13406?versionId=0270dd11-3368-4b03-9660-a2320f113572&runId=a71d74b7-b2cf-4e97-9923-c10e2cea0ae5&agentId=5E79gM4wauFLmWHY8c5ggyYczspbmW2ZwfUCijxz8xprpHpY) 
we can see, agent calls 
ls -l .
and gets 0 files

next_thought: I need to understand the current project structure first. Let me start by checking what files exist in the current directory to see if this is a Django project and locate the relevant files.
next_tool_name: run_bash_command
next_tool_args: {'cmd': 'ls -l .'}
observation: stdout=total 0

The root cause of this is the repo_cache for this swe-bench-instance is empty (no .git subfolder even )

# Solution: 

each time at sandbox creation check that cache directory for swe-bench instance not only exists, but has .git subfolder and repo can be correctly intialized, otherwise - reclone it. These is done already inside `repo_clone` method. 
So we should call this method everytime at sandbox initialization.
There will be no excessive bandwidth usage, because repo will be recloned only if it is broken or repo folder empty.

# Hot to test

deploy this fix ion screener-1-5 and check that swe-bench instance `django__django-13406` now solved or at leas agent can find python source code.