### PR TITLE
screener/agent status bug fix

### DIFF
--- a/api/src/backend/queries/evaluations.py
+++ b/api/src/backend/queries/evaluations.py
@@ -440,3 +440,13 @@ async def get_miner_hotkey_from_version_id(conn: asyncpg.Connection, version_id:
         FROM miner_agents 
         WHERE version_id = $1
     """, version_id)
+
+@db_operation
+async def is_screener_running_evaluation(conn: asyncpg.Connection, validator_hotkey: str) -> bool:
+    """Check if a screener is running an evaluation"""
+    return await conn.fetchval(
+        """
+        SELECT EXISTS(SELECT 1 FROM evaluations WHERE validator_hotkey = $1 AND status = 'running')
+        """,
+        validator_hotkey
+    )

--- a/api/src/endpoints/upload.py
+++ b/api/src/endpoints/upload.py
@@ -111,6 +111,17 @@ async def post_agent(
                         status_code=503,
                         detail="No stage 1 screeners available for agent evaluation. Please try again later."
                     )
+                
+                # Check is there is an evaluation in the database with the screener's hotkey that has running status
+                # This is to prevent the case where a screener.is_available() returns true but the screener is actually running an evaluation
+                from api.src.backend.queries.evaluations import is_screener_running_evaluation
+                is_screener_running_evaluation = await is_screener_running_evaluation(screener.hotkey)
+                if is_screener_running_evaluation:
+                    logger.error(f"No available stage 1 screener for agent upload from miner {miner_hotkey} - screener {screener.hotkey} said it was available but there is an evaluation in the database with the screener's hotkey that has running status")
+                    raise HTTPException(
+                        status_code=409,
+                        detail="No stage 1 screeners available for agent evaluation. Please try again later."
+                    )
 
                 async with get_transaction() as conn:
                     can_upload = await Evaluation.check_miner_has_no_running_evaluations(conn, miner_hotkey)


### PR DESCRIPTION
- added database function to queries/evaluations.py to check if there are any running evaluations that have a given validator hotkey
- added a database check in upload.py that runs ^ this database function to confirm get_first_available_screener gave us a screener that is not actively being used for an evaluation