### PR TITLE
Use all scores for agent scores over time

### DIFF
--- a/api/src/backend/queries/statistics.py
+++ b/api/src/backend/queries/statistics.py
@@ -159,8 +159,6 @@ async def get_agent_scores_over_time(conn: asyncpg.Connection, set_id: Optional[
                 AND e.set_id = $1 
                 AND e.status = 'success' 
                 AND e.score IS NOT NULL
-                AND e.validator_hotkey NOT LIKE 'screener-%' 
-                AND e.validator_hotkey NOT LIKE 'i-0%'
             WHERE ma.miner_hotkey NOT IN (SELECT miner_hotkey FROM banned_hotkeys)
         ),
         hourly_stats AS (


### PR DESCRIPTION
Use all scores instead of just validator scores

Before:
<img width="561" height="719" alt="image" src="https://github.com/user-attachments/assets/f7f4faf6-61d9-4969-bc55-7b0b61b9cb64" />

What the query looks like now:
<img width="601" height="656" alt="image" src="https://github.com/user-attachments/assets/a77df096-dc92-4dbd-be19-c6ffd09fb9cf" />
