### PR TITLE
Update top scores to use `set_id` and `banned_agents`

### DIFF
--- a/api/src/endpoints/retrieval.py
+++ b/api/src/endpoints/retrieval.py
@@ -5,7 +5,7 @@ import utils.logger as logger
 from dotenv import load_dotenv
 
 from api.src.utils.auth import verify_request_public
-from queries.statistics import get_top_scores_over_last_week
+from queries.statistics import get_top_scores_over_time
 
 
 load_dotenv()
@@ -160,7 +160,7 @@ async def top_scores_over_time():
     if recalculating_cache.get(cache_key, False) and cache_key in cache_data:
         return cache_data[cache_key]
     recalculating_cache[cache_key] = True
-    cache_data[cache_key] = await get_top_scores_over_last_week()
+    cache_data[cache_key] = await get_top_scores_over_time()
     cache_timestamps[cache_key] = time.time()
     recalculating_cache[cache_key] = False
     return cache_data[cache_key]

--- a/queries/statistics.py
+++ b/queries/statistics.py
@@ -17,14 +17,27 @@ async def score_improvement_24_hrs(conn: DatabaseConnection):
     return await conn.fetchval("SELECT COALESCE((SELECT MAX(final_score) FROM agent_scores WHERE set_id = (SELECT MAX(set_id) FROM evaluation_sets)) - COALESCE((SELECT MAX(final_score) FROM agent_scores WHERE set_id = (SELECT MAX(set_id) FROM evaluation_sets) - 1), 0), 0)")
 
 @db_operation
-async def get_top_scores_over_last_week(conn: DatabaseConnection) -> list[dict]:
-    # TODO: Hardcoded start time since it's slow to get the minimum date from the agent_scores view. We don't have indexes
+async def get_top_scores_over_time(conn: DatabaseConnection) -> list[dict]:
     query = """
         WITH
+        max_set AS (
+            SELECT MAX(set_id) as set_id FROM evaluation_sets
+        ),
         time_series AS (
             SELECT
             generate_series(
-                '2025-10-15 22:00:00.000000 +00:00',
+                (
+                SELECT
+                    MIN(DATE_TRUNC('hour', agent_scores.created_at))
+                FROM
+                    agent_scores
+                JOIN
+                    agents a ON agent_scores.agent_id = a.agent_id
+                WHERE
+                    agent_scores.final_score IS NOT NULL
+                    AND agent_scores.set_id = (SELECT set_id FROM max_set)
+                    AND a.miner_hotkey NOT IN (SELECT miner_hotkey FROM banned_hotkeys)
+                ),
                 DATE_TRUNC('hour', NOW()),
                 '1 hour'::interval
             ) as hour
@@ -34,12 +47,16 @@ async def get_top_scores_over_last_week(conn: DatabaseConnection) -> list[dict]:
         COALESCE(
             (
             SELECT
-                MAX(final_score)
+                MAX(agent_scores.final_score)
             FROM
                 agent_scores
+            JOIN
+                agents a ON agent_scores.agent_id = a.agent_id
             WHERE
-                final_score IS NOT NULL
-                AND created_at <= ts.hour
+                agent_scores.final_score IS NOT NULL
+                AND agent_scores.created_at <= ts.hour
+                AND agent_scores.set_id = (SELECT set_id FROM max_set)
+                AND a.miner_hotkey NOT IN (SELECT miner_hotkey FROM banned_hotkeys)
             ),
             0
         ) as top_score


### PR DESCRIPTION
<img width="886" height="505" alt="image" src="https://github.com/user-attachments/assets/e5bb2c6a-b53f-4ace-98fe-3a37dc3d6979" />

- Always get biggest set_id
- Don't include scores from banned agents