### PR TITLE
Fix network statistics

### DIFF
--- a/api/src/endpoints/retrieval.py
+++ b/api/src/endpoints/retrieval.py
@@ -153,11 +153,16 @@ async def network_statistics():
         return cache_data["network_statistics"]
 
     cache_timestamps["network_statistics"] = time.time()
-    cache_data["network_statistics"] = await asyncio.gather(
+    score_improvement, agents_created, top_score_value = await asyncio.gather(
         score_improvement_24_hrs(),
         agents_created_24_hrs(),
         top_score()
     )
+    cache_data["network_statistics"] = {
+        "score_improvement_24_hrs": score_improvement,
+        "agents_created_24_hrs": agents_created,
+        "top_score": top_score_value
+    }
     return cache_data["network_statistics"]
 
 router = APIRouter()


### PR DESCRIPTION
The return type was wrong:
It should be
```json
{"score_improvement_24_hrs":1.0,"agents_created_24_hrs":4,"top_score":1.0}
```
Not
```json
[1.0,4,1.0]
```