### PR TITLE
Check agent before payment + check successful payment 

### DIFF
--- a/ridges.py
+++ b/ridges.py
@@ -119,7 +119,6 @@ def upload(ctx, file: Optional[str], coldkey_name: Optional[str], hotkey_name: O
                 'name': name,
                 'payment_time': time.time()
             }
-            
             check_response = client.post(f"{ridges.api_url}/upload/agent/check", files={'agent_file': ('agent.py', file_content, 'text/plain')}, data=check_payload, timeout=120)
             if check_response.status_code != 200:
                 console.print(f"Error checking agent: {check_response.text}", style="bold red")
@@ -171,7 +170,7 @@ def upload(ctx, file: Optional[str], coldkey_name: Optional[str], hotkey_name: O
                 'payment_time': payment_time_start
             }
 
-            console.print(f"\n[yellow]Payment successful. If something goes wrong with the upload, you can use these information to get a refund[/yellow]")
+            console.print(f"\n[yellow]Payment extrinsic submitted. If something goes wrong with the upload, you can use this information to get a refund[/yellow]")
             console.print(f"[cyan]Payment Block Hash:[/cyan] {receipt.block_hash}")
             console.print(f"[cyan]Payment Extrinsic Index:[/cyan] {receipt.extrinsic_idx}\n")
 


### PR DESCRIPTION
pre-check:
<img width="1280" height="178" alt="image" src="https://github.com/user-attachments/assets/3ad21112-a2a6-4513-9bd4-9eca8ffc6a91" />

in case the user comments out the pre-check:
<img width="1277" height="286" alt="image" src="https://github.com/user-attachments/assets/25712b28-2e5b-4bbb-ace3-f389eecbd463" />

<details>
<summary>Example of successful extrinsic events</summary>

```py
[{'attributes': {'dispatch_info': {'class': 'Mandatory',
                                   'pays_fee': 'Yes',
                                   'weight': {'proof_size': 1493,
                                              'ref_time': 261973000}}},
  'event': {'attributes': {'dispatch_info': {'class': 'Mandatory',
                                             'pays_fee': 'Yes',
                                             'weight': {'proof_size': 1493,
                                                        'ref_time': 261973000}}},
            'event_id': 'ExtrinsicSuccess',
            'event_index': '0000',
            'module_id': 'System'},
  'event_id': 'ExtrinsicSuccess',
  'event_index': 0,
  'extrinsic_idx': 0,
  'module_id': 'System',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'amount': 13757,
                 'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
  'event': {'attributes': {'amount': 13757,
                           'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
            'event_id': 'Withdraw',
            'event_index': '0508',
            'module_id': 'Balances'},
  'event_id': 'Withdraw',
  'event_index': 5,
  'extrinsic_idx': 1,
  'module_id': 'Balances',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'account': '5F4Thj3LRZdjSAnUhymAVVq2X2czSAKD4uGNCnqW8JrCHWE4'},
  'event': {'attributes': {'account': '5F4Thj3LRZdjSAnUhymAVVq2X2czSAKD4uGNCnqW8JrCHWE4'},
            'event_id': 'NewAccount',
            'event_index': '0003',
            'module_id': 'System'},
  'event_id': 'NewAccount',
  'event_index': 0,
  'extrinsic_idx': 1,
  'module_id': 'System',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'account': '5F4Thj3LRZdjSAnUhymAVVq2X2czSAKD4uGNCnqW8JrCHWE4',
                 'free_balance': 257258360896},
  'event': {'attributes': {'account': '5F4Thj3LRZdjSAnUhymAVVq2X2czSAKD4uGNCnqW8JrCHWE4',
                           'free_balance': 257258360896},
            'event_id': 'Endowed',
            'event_index': '0500',
            'module_id': 'Balances'},
  'event_id': 'Endowed',
  'event_index': 5,
  'extrinsic_idx': 1,
  'module_id': 'Balances',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'amount': 257258360896,
                 'from': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm',
                 'to': '5F4Thj3LRZdjSAnUhymAVVq2X2czSAKD4uGNCnqW8JrCHWE4'},
  'event': {'attributes': {'amount': 257258360896,
                           'from': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm',
                           'to': '5F4Thj3LRZdjSAnUhymAVVq2X2czSAKD4uGNCnqW8JrCHWE4'},
            'event_id': 'Transfer',
            'event_index': '0502',
            'module_id': 'Balances'},
  'event_id': 'Transfer',
  'event_index': 5,
  'extrinsic_idx': 1,
  'module_id': 'Balances',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'amount': 0,
                 'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
  'event': {'attributes': {'amount': 0,
                           'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
            'event_id': 'Deposit',
            'event_index': '0507',
            'module_id': 'Balances'},
  'event_id': 'Deposit',
  'event_index': 5,
  'extrinsic_idx': 1,
  'module_id': 'Balances',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'actual_fee': 13757,
                 'tip': 0,
                 'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
  'event': {'attributes': {'actual_fee': 13757,
                           'tip': 0,
                           'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
            'event_id': 'TransactionFeePaid',
            'event_index': '0600',
            'module_id': 'TransactionPayment'},
  'event_id': 'TransactionFeePaid',
  'event_index': 6,
  'extrinsic_idx': 1,
  'module_id': 'TransactionPayment',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'dispatch_info': {'class': 'Normal',
                                   'pays_fee': 'Yes',
                                   'weight': {'proof_size': 3593,
                                              'ref_time': 272208000}}},
  'event': {'attributes': {'dispatch_info': {'class': 'Normal',
                                             'pays_fee': 'Yes',
                                             'weight': {'proof_size': 3593,
                                                        'ref_time': 272208000}}},
            'event_id': 'ExtrinsicSuccess',
            'event_index': '0000',
            'module_id': 'System'},
  'event_id': 'ExtrinsicSuccess',
  'event_index': 0,
  'extrinsic_idx': 1,
  'module_id': 'System',
  'phase': 'ApplyExtrinsic',
  'topics': []}]
```
</details>


<details>
<summary>Example of failed extrinsic events</summary>

```py
[{'attributes': {'dispatch_info': {'class': 'Mandatory',
                                   'pays_fee': 'Yes',
                                   'weight': {'proof_size': 1493,
                                              'ref_time': 261973000}}},
  'event': {'attributes': {'dispatch_info': {'class': 'Mandatory',
                                             'pays_fee': 'Yes',
                                             'weight': {'proof_size': 1493,
                                                        'ref_time': 261973000}}},
            'event_id': 'ExtrinsicSuccess',
            'event_index': '0000',
            'module_id': 'System'},
  'event_id': 'ExtrinsicSuccess',
  'event_index': 0,
  'extrinsic_idx': 0,
  'module_id': 'System',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'amount': 13757,
                 'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
  'event': {'attributes': {'amount': 13757,
                           'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
            'event_id': 'Withdraw',
            'event_index': '0508',
            'module_id': 'Balances'},
  'event_id': 'Withdraw',
  'event_index': 5,
  'extrinsic_idx': 1,
  'module_id': 'Balances',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'account': '5F4Thj3LRZdjSAnUhymAVVq2X2czSAKD4uGNCnqW8JrCHWE4'},
  'event': {'attributes': {'account': '5F4Thj3LRZdjSAnUhymAVVq2X2czSAKD4uGNCnqW8JrCHWE4'},
            'event_id': 'NewAccount',
            'event_index': '0003',
            'module_id': 'System'},
  'event_id': 'NewAccount',
  'event_index': 0,
  'extrinsic_idx': 1,
  'module_id': 'System',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'account': '5F4Thj3LRZdjSAnUhymAVVq2X2czSAKD4uGNCnqW8JrCHWE4',
                 'free_balance': 257258360896},
  'event': {'attributes': {'account': '5F4Thj3LRZdjSAnUhymAVVq2X2czSAKD4uGNCnqW8JrCHWE4',
                           'free_balance': 257258360896},
            'event_id': 'Endowed',
            'event_index': '0500',
            'module_id': 'Balances'},
  'event_id': 'Endowed',
  'event_index': 5,
  'extrinsic_idx': 1,
  'module_id': 'Balances',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'amount': 257258360896,
                 'from': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm',
                 'to': '5F4Thj3LRZdjSAnUhymAVVq2X2czSAKD4uGNCnqW8JrCHWE4'},
  'event': {'attributes': {'amount': 257258360896,
                           'from': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm',
                           'to': '5F4Thj3LRZdjSAnUhymAVVq2X2czSAKD4uGNCnqW8JrCHWE4'},
            'event_id': 'Transfer',
            'event_index': '0502',
            'module_id': 'Balances'},
  'event_id': 'Transfer',
  'event_index': 5,
  'extrinsic_idx': 1,
  'module_id': 'Balances',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'amount': 0,
                 'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
  'event': {'attributes': {'amount': 0,
                           'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
            'event_id': 'Deposit',
            'event_index': '0507',
            'module_id': 'Balances'},
  'event_id': 'Deposit',
  'event_index': 5,
  'extrinsic_idx': 1,
  'module_id': 'Balances',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'actual_fee': 13757,
                 'tip': 0,
                 'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
  'event': {'attributes': {'actual_fee': 13757,
                           'tip': 0,
                           'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
            'event_id': 'TransactionFeePaid',
            'event_index': '0600',
            'module_id': 'TransactionPayment'},
  'event_id': 'TransactionFeePaid',
  'event_index': 6,
  'extrinsic_idx': 1,
  'module_id': 'TransactionPayment',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'dispatch_info': {'class': 'Normal',
                                   'pays_fee': 'Yes',
                                   'weight': {'proof_size': 3593,
                                              'ref_time': 272208000}}},
  'event': {'attributes': {'dispatch_info': {'class': 'Normal',
                                             'pays_fee': 'Yes',
                                             'weight': {'proof_size': 3593,
                                                        'ref_time': 272208000}}},
            'event_id': 'ExtrinsicSuccess',
            'event_index': '0000',
            'module_id': 'System'},
  'event_id': 'ExtrinsicSuccess',
  'event_index': 0,
  'extrinsic_idx': 1,
  'module_id': 'System',
  'phase': 'ApplyExtrinsic',
  'topics': []}]
INFO:     ::1:53952 - "POST /upload/agent HTTP/1.1" 200 OK
INFO:     ::1:56141 - "GET /retrieval/agent-by-hotkey?miner_hotkey=5CPqBJEhyox7jr8ki38MbWjY1EX3ucnvp1bp41wdEZVdA5GE HTTP/1.1" 200 OK
INFO:     ::1:56141 - "POST /upload/agent/check HTTP/1.1" 200 OK
INFO:     ::1:56141 - "GET /upload/eval-pricing HTTP/1.1" 200 OK
[{'attributes': {'dispatch_info': {'class': 'Mandatory',
                                   'pays_fee': 'Yes',
                                   'weight': {'proof_size': 1493,
                                              'ref_time': 261973000}}},
  'event': {'attributes': {'dispatch_info': {'class': 'Mandatory',
                                             'pays_fee': 'Yes',
                                             'weight': {'proof_size': 1493,
                                                        'ref_time': 261973000}}},
            'event_id': 'ExtrinsicSuccess',
            'event_index': '0000',
            'module_id': 'System'},
  'event_id': 'ExtrinsicSuccess',
  'event_index': 0,
  'extrinsic_idx': 0,
  'module_id': 'System',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'amount': 13757,
                 'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
  'event': {'attributes': {'amount': 13757,
                           'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
            'event_id': 'Withdraw',
            'event_index': '0508',
            'module_id': 'Balances'},
  'event_id': 'Withdraw',
  'event_index': 5,
  'extrinsic_idx': 1,
  'module_id': 'Balances',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'amount': 0,
                 'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
  'event': {'attributes': {'amount': 0,
                           'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
            'event_id': 'Deposit',
            'event_index': '0507',
            'module_id': 'Balances'},
  'event_id': 'Deposit',
  'event_index': 5,
  'extrinsic_idx': 1,
  'module_id': 'Balances',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'actual_fee': 13757,
                 'tip': 0,
                 'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
  'event': {'attributes': {'actual_fee': 13757,
                           'tip': 0,
                           'who': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm'},
            'event_id': 'TransactionFeePaid',
            'event_index': '0600',
            'module_id': 'TransactionPayment'},
  'event_id': 'TransactionFeePaid',
  'event_index': 6,
  'extrinsic_idx': 1,
  'module_id': 'TransactionPayment',
  'phase': 'ApplyExtrinsic',
  'topics': []},
 {'attributes': {'dispatch_error': {'Token': 'FundsUnavailable'},
                 'dispatch_info': {'class': 'Normal',
                                   'pays_fee': 'Yes',
                                   'weight': {'proof_size': 3593,
                                              'ref_time': 272208000}}},
  'event': {'attributes': {'dispatch_error': {'Token': 'FundsUnavailable'},
                           'dispatch_info': {'class': 'Normal',
                                             'pays_fee': 'Yes',
                                             'weight': {'proof_size': 3593,
                                                        'ref_time': 272208000}}},
            'event_id': 'ExtrinsicFailed',
            'event_index': '0001',
            'module_id': 'System'},
  'event_id': 'ExtrinsicFailed',
  'event_index': 0,
  'extrinsic_idx': 1,
  'module_id': 'System',
  'phase': 'ApplyExtrinsic',
  'topics': []}]
```
</details>