### PR TITLE
Backport tests from polyglot python to JS

### DIFF
--- a/evaluator/datasets/polyglot_js/pig-latin/tests.js
+++ b/evaluator/datasets/polyglot_js/pig-latin/tests.js
@@ -44,10 +44,6 @@ describe('Pig Latin', () => {
     xtest('word beginning with q without a following u', () => {
       expect(translate('qat')).toEqual('atqay');
     });
-
-    xtest('word beginning with consonant and vowel containing qu', () => {
-      expect(translate('liquid')).toEqual('iquidlay');
-    });
   });
 
   describe('some letter clusters are treated like a single consonant', () => {

--- a/evaluator/datasets/polyglot_js/robot-name/main.js
+++ b/evaluator/datasets/polyglot_js/robot-name/main.js
@@ -15,11 +15,9 @@ export class Robot {
     reset() {
         throw new Error('Remove this line and implement the function');
     }
-
-    /**
-     * @return {void}
-     */
-    releaseNames() {
-        throw new Error('Remove this line and implement the function');
-    }
 }
+
+/**
+ * @return {void}
+ */
+Robot.releaseNames = () => {};

--- a/evaluator/datasets/polyglot_js/two-bucket/tests.js
+++ b/evaluator/datasets/polyglot_js/two-bucket/tests.js
@@ -74,22 +74,6 @@ describe('TwoBucket', () => {
     });
   });
 
-  xtest('Measure using bucket one much bigger than bucket two', () => {
-    const twoBucket = new TwoBucket(5, 1, 2, 'one');
-    const result = twoBucket.solve();
-    expect(result.moves).toEqual(6);
-    expect(result.goalBucket).toEqual('one');
-    expect(result.otherBucket).toEqual(1);
-  });
-
-  xtest('Measure using bucket one much smaller than bucket two', () => {
-    const twoBucket = new TwoBucket(3, 15, 9, 'one');
-    const result = twoBucket.solve();
-    expect(result.moves).toEqual(6);
-    expect(result.goalBucket).toEqual('two');
-    expect(result.otherBucket).toEqual(0);
-  });
-
   xtest('Not possible to reach the goal', () => {
     expect(() => new TwoBucket(6, 15, 5, 'one')).toThrow();
   });

--- a/evaluator/datasets/polyglot_js/variable-length-quantity/tests.js
+++ b/evaluator/datasets/polyglot_js/variable-length-quantity/tests.js
@@ -11,10 +11,6 @@ describe('VariableLengthQuantity', () => {
       expect(encode([0x40])).toEqual([0x40]);
     });
 
-    xtest('asymmetric single byte', () => {
-      expect(encode([0x53])).toEqual([0x53]);
-    });
-
     xtest('largest single byte', () => {
       expect(encode([0x7f])).toEqual([0x7f]);
     });
@@ -25,10 +21,6 @@ describe('VariableLengthQuantity', () => {
 
     xtest('arbitrary double byte', () => {
       expect(encode([0x2000])).toEqual([0xc0, 0]);
-    });
-
-    xtest('asymmetric double byte', () => {
-      expect(encode([0xad])).toEqual([0x81, 0x2d]);
     });
 
     xtest('largest double byte', () => {
@@ -43,10 +35,6 @@ describe('VariableLengthQuantity', () => {
       expect(encode([0x100000])).toEqual([0xc0, 0x80, 0]);
     });
 
-    xtest('asymmetric triple byte', () => {
-      expect(encode([0x1d59c])).toEqual([0x87, 0xab, 0x1c]);
-    });
-
     xtest('largest triple byte', () => {
       expect(encode([0x1fffff])).toEqual([0xff, 0xff, 0x7f]);
     });
@@ -59,10 +47,6 @@ describe('VariableLengthQuantity', () => {
       expect(encode([0x8000000])).toEqual([0xc0, 0x80, 0x80, 0]);
     });
 
-    xtest('asymmetric quadruple byte', () => {
-      expect(encode([0x357704])).toEqual([0x81, 0xd5, 0xee, 0x04]);
-    });
-
     xtest('largest quadruple byte', () => {
       expect(encode([0xfffffff])).toEqual([0xff, 0xff, 0xff, 0x7f]);
     });
@@ -73,10 +57,6 @@ describe('VariableLengthQuantity', () => {
 
     xtest('arbitrary quintuple byte', () => {
       expect(encode([0xff000000])).toEqual([0x8f, 0xf8, 0x80, 0x80, 0]);
-    });
-
-    xtest('asymmetric quintuple byte', () => {
-      expect(encode([0x86656105])).toEqual([0x88, 0xb3, 0x95, 0xc2, 0x05]);
     });
 
     xtest('maximum 32-bit integer input', () => {

--- a/evaluator/datasets/polyglot_js/wordy/tests.js
+++ b/evaluator/datasets/polyglot_js/wordy/tests.js
@@ -6,24 +6,8 @@ describe('Wordy', () => {
     expect(answer('What is 5?')).toEqual(5);
   });
 
-  xtest('just a zero', () => {
-    expect(answer('What is 0?')).toEqual(0);
-  });
-
-  xtest('just a negative number', () => {
-    expect(answer('What is -123?')).toEqual(-123);
-  });
-
   xtest('addition', () => {
     expect(answer('What is 1 plus 1?')).toEqual(2);
-  });
-
-  xtest('addition with a left hand zero', () => {
-    expect(answer('What is 0 plus 2?')).toEqual(2);
-  });
-
-  xtest('addition with a right hand zero', () => {
-    expect(answer('What is 3 plus 0?')).toEqual(3);
   });
 
   xtest('more addition', () => {


### PR DESCRIPTION
Command used to find polyglot python patches 
```bash
git diff e045ace314cf6ac3c777de1bbee45ae843cb3986 3ecc9654ca002416094152008761158f861a8986
```
Tests that were modified:
- `dot-dsl`: doesn't exist
- `go-counting`: the python tests were modified so that the agent doesn't need to define the constants
  ```diff
  diff --git a/evaluator/datasets/polyglot_py/go-counting/tests.py b/evaluator/datasets/polyglot_py/go-counting/tests.py
  index d69cad7a..e57c9cc4 100644
  --- a/evaluator/datasets/polyglot_py/go-counting/tests.py
  +++ b/evaluator/datasets/polyglot_py/go-counting/tests.py
  @@ -4,12 +4,11 @@

  import unittest

  -from main import (
  -    Board,
  -    WHITE,
  -    BLACK,
  -    NONE,
  -)
  +from main import Board
  +
  +WHITE = "W"
  +BLACK = "B"
  +NONE = ""


  class GoCountingTest(unittest.TestCase):
  ```
  The JS tests doesn't do that, and I also define the exact return type `@return {{owner: 'BLACK' | 'WHITE' | 'NONE', territory: [number, number][]}}` so I don't think I need to modify the tests here 


- `grep`
  Not too sure. The python tests were modified to fix some mocking thing, but the JS ones don't have it
  ```diff
  --- a/evaluator/datasets/polyglot_py/grep/tests.py
  +++ b/evaluator/datasets/polyglot_py/grep/tests.py
  @@ -47,7 +47,7 @@ def open_mock(fname, *args, **kwargs):
          )


  -@mock.patch("grep.open", name="open", side_effect=open_mock, create=True)
  +@mock.patch("main.open", name="open", side_effect=open_mock, create=True)
  @mock.patch("io.StringIO", name="StringIO", wraps=io.StringIO)
  class GrepTest(unittest.TestCase):
      # Test grepping a single file
  ```

- `hangman`: not in JS
- `pig-latin`: fixed
- `pov`: doesn't exist
- `tree-building` doesn't exist
- `two-bucket`: fixed

For solutions:
- `robot-names`: there was a patch to the python version to use a set, to avoid collisions. The JS one uses some shuffling algorithm so that collisions never happen. I realized I made a mistake when adding types. I moved the `releaseNames` into the `Robot` class, but turns out, having it outside makes the method static