### PR TITLE
fix: prevent signature replay attacks in agent upload

### DIFF
--- a/api/src/endpoints/upload.py
+++ b/api/src/endpoints/upload.py
@@ -63,10 +63,11 @@ async def check_agent_post(
     request: Request,
     agent_file: UploadFile = File(..., description="Python file containing the agent code (must be named agent.py)"),
     public_key: str = Form(..., description="Public key of the miner in hex format"),
-    file_info: str = Form(..., description="File information containing miner hotkey and version number (format: hotkey:version)"),
+    file_info: str = Form(..., description="File information containing miner hotkey, hash, version, and timestamp (format: hotkey:hash:version:timestamp)"),
     signature: str = Form(..., description="Signature to verify the authenticity of the upload"),
     name: str = Form(..., description="Name of the agent"),
     payment_time: float = Form(..., description="Timestamp of the payment"),
+    timestamp: int = Form(..., description="Unix timestamp when signature was created"),
 ) -> AgentUploadResponse:
     miner_hotkey = get_miner_hotkey(file_info)
     check_signature(public_key, file_info, signature)
@@ -103,12 +104,13 @@ async def post_agent(
     request: Request,
     agent_file: UploadFile = File(..., description="Python file containing the agent code (must be named agent.py)"),
     public_key: str = Form(..., description="Public key of the miner in hex format"),
-    file_info: str = Form(..., description="File information containing miner hotkey and version number (format: hotkey:version)"),
+    file_info: str = Form(..., description="File information containing miner hotkey, hash, version, and timestamp (format: hotkey:hash:version:timestamp)"),
     signature: str = Form(..., description="Signature to verify the authenticity of the upload"),
     name: str = Form(..., description="Name of the agent"),
     payment_block_hash: str = Form(..., description="Block hash in which payment was made"),
     payment_extrinsic_index: str = Form(..., description="Index in the block for payment extrinsic"),
     payment_time: float = Form(..., description="Timestamp of the payment"),
+    timestamp: int = Form(..., description="Unix timestamp when signature was created"),
 ) -> AgentUploadResponse:
     """
     Upload a new agent version for evaluation


### PR DESCRIPTION
## 🔒 Fix: Prevent Signature Replay Attacks in Agent Upload

### Problem
The current signature verification system is vulnerable to replay attacks. Signatures never expire and can be captured and reused indefinitely to upload unauthorized agents.

**Vulnerability:**
- Signatures only cover `hotkey:hash:version` (no timestamp)
- Valid signatures have infinite lifetime
- Attackers can intercept and replay signatures with different agent code

### Exploit Scenario
```python
# Attacker captures legitimate upload request
captured_signature = "0x1234..."
captured_file_info = "5Abc...xyz:sha256hash:0"

# Days later, replays with MALICIOUS code
malicious_code = b"import os; os.system('rm -rf /')"

# Upload succeeds - signature is still valid! ❌
requests.post(
    "https://platform-v2.ridges.ai/upload/agent",
    files={'agent_file': ('agent.py', malicious_code)},
    data={
        'file_info': captured_file_info,  # Same
        'signature': captured_signature,   # Replayed
        # ...
    }
)
```

**Impact:** Unauthorized agent uploads, potential system compromise

---

### Solution

Add timestamps to signature payload and validate freshness (5-minute expiry window).

**Before:**
```python
file_info = f"{hotkey}:{hash}:{version}"
```

**After:**
```python
timestamp = int(time.time())
file_info = f"{hotkey}:{hash}:{version}:{timestamp}"
```

**Server validates:**
1. ✅ Format: 4 parts required (`hotkey:hash:version:timestamp`)
2. ✅ Timestamp freshness: max 5 minutes old
3. ✅ Cryptographic signature: valid for the payload

---

### Security Properties

✅ **Time-bound validity** - Signatures expire after 5 minutes  
✅ **Replay prevention** - Old signatures automatically rejected  
✅ **Stateless validation** - No database tracking needed  
✅ **Backward compatible** - Old clients fail with clear errors  
✅ **Configurable** - `max_age_seconds` parameter for tuning  

---

### Changes Made

**Files Modified:**
- `ridges.py` - CLI adds timestamps to signatures (2 locations)
- `api/src/utils/upload_agent_helpers.py` - Enhanced `check_signature()` with replay prevention
- `api/src/endpoints/upload.py` - Added `timestamp` parameter to endpoints

---

### Testing

All tests passing ✅

```bash
$ python test_signature_replay.py

============================================================
TEST 1: Signature Format                            ✓ PASSED
TEST 2: Signature Expiry                            ✓ PASSED
TEST 3: Replay Attack Prevention                    ✓ PASSED
TEST 4: Format Validation                           ✓ PASSED
TEST 5: Timestamp Validation                        ✓ PASSED
============================================================
ALL TESTS PASSED ✓
```

**Test Coverage:**
- ✅ Fresh signatures accepted
- ✅ Expired signatures (>5 min) rejected
- ✅ Replay attacks prevented
- ✅ Old format (3 parts) rejected with clear error
- ✅ Invalid timestamps rejected

---

### Migration Notes

**For Miners:**
- Update CLI: `git pull && python ridges.py upload ...`
- Old CLI versions will get clear error: `"Invalid file_info format (expected: hotkey:hash:version:timestamp)"`

**For Validators:**
- No changes required

**For Platform:**
- Deploy server changes first
- No database migration needed
- Old clients fail gracefully with descriptive errors

---


### Related

This fix prevents gaming via signature reuse and complements other security improvements in the upload pipeline.

