### PR TITLE
add validator hotkey to problem stats

### DIFF
--- a/queries/problem_statistics.py
+++ b/queries/problem_statistics.py
@@ -29,9 +29,10 @@ class ProblemStatisticsRecentErroredAgentInfo(BaseModel):
     agent_id: UUID
     name: str
     version_num: int
-    validator_hotkey: str
 
     evaluation_id: UUID
+    evaluation_validator_hotkey: str
+    
     evaluation_run_id: UUID
     evaluation_run_started_at: datetime
     evaluation_run_errored_at: datetime
@@ -215,8 +216,8 @@ async def get_problem_statistics(conn: DatabaseConnection) -> List[ProblemStatis
                             'agent_id', agent_id,
                             'name', name,
                             'version_num', version_num,
-                            'validator_hotkey', validator_hotkey,
                             'evaluation_id', evaluation_id,
+                            'evaluation_validator_hotkey', evaluation_validator_hotkey,
                             'evaluation_run_id', evaluation_run_id,
                             'evaluation_run_started_at', evaluation_run_started_at,
                             'evaluation_run_errored_at', evaluation_run_errored_at,
@@ -230,8 +231,8 @@ async def get_problem_statistics(conn: DatabaseConnection) -> List[ProblemStatis
                         a.agent_id,
                         a.name,
                         a.version_num,
-                        e.validator_hotkey,
                         er.evaluation_id,
+                        e.validator_hotkey as evaluation_validator_hotkey,
                         er.evaluation_run_id,
                         er.created_at AS evaluation_run_started_at,
                         er.finished_or_errored_at AS evaluation_run_errored_at,


### PR DESCRIPTION
Test
```bash
curl localhost:8000/statistics/problem-statistics | jq
```

[problem-stats-result.json](https://github.com/user-attachments/files/24119321/problem-stats-result.json)


<details>
<summary>Example JSON</summary>

```json
{
  "problem_stats": [
    {
      "problem_name": "alphametics-js",
      "problem_suite_name": "polyglot_js",
      "problem_difficulty": null,
      "total_num_evaluation_runs": 983,
      "num_finished_evaluation_runs": 884,
      "num_finished_passed_evaluation_runs": 337,
      "num_finished_failed_evaluation_runs": 547,
      "num_errored_evaluation_runs": 97,
      "pass_rate": 0.38122171945701355,
      "average_time": 1067.711433185525,
      "average_cost_usd": 0.30028245508646995,
      "in_screener_1_set_group": false,
      "in_screener_2_set_group": true,
      "in_validator_set_group": true,
      "tests": [
        {
          "name": "puzzle with ten letters and 199 addends",
          "category": "default",
          "num_runs": 884,
          "num_passed": 345,
          "num_failed": 539,
          "pass_rate": 0.3902714932126697
        },
        {
          "name": "leading zero solution is invalid",
          "category": "default",
          "num_runs": 884,
          "num_passed": 712,
          "num_failed": 172,
          "pass_rate": 0.8054298642533937
        },
        {
          "name": "puzzle with six letters",
          "category": "default",
          "num_runs": 884,
          "num_passed": 348,
          "num_failed": 536,
          "pass_rate": 0.3936651583710407
        },
        {
          "name": "puzzle with seven letters",
          "category": "default",
          "num_runs": 884,
          "num_passed": 346,
          "num_failed": 538,
          "pass_rate": 0.3914027149321267
        },
        {
          "name": "puzzle with three letters",
          "category": "default",
          "num_runs": 884,
          "num_passed": 359,
          "num_failed": 525,
          "pass_rate": 0.4061085972850679
        },
        {
          "name": "puzzle with eight letters",
          "category": "default",
          "num_runs": 884,
          "num_passed": 354,
          "num_failed": 530,
          "pass_rate": 0.4004524886877828
        },
        {
          "name": "solution must have unique value for each letter",
          "category": "default",
          "num_runs": 884,
          "num_passed": 718,
          "num_failed": 166,
          "pass_rate": 0.8122171945701357
        },
        {
          "name": "puzzle with four letters",
          "category": "default",
          "num_runs": 884,
          "num_passed": 356,
          "num_failed": 528,
          "pass_rate": 0.40271493212669685
        },
        {
          "name": "puzzle with ten letters",
          "category": "default",
          "num_runs": 884,
          "num_passed": 345,
          "num_failed": 539,
          "pass_rate": 0.3902714932126697
        }
      ],
      "error_code_distribution": [
        {
          "error_code": 1010,
          "error_message": "The agent raised an exception while being evaluated",
          "recent_errored_agents": [
            {
              "agent_id": "05fe11a4-d984-46b6-9b9b-e6224c7c2b86",
              "name": "healer",
              "version_num": 2,
              "validator_hotkey": "5GgJptBaUiWwb8SQDinZ9rDQoVw47mgduXaCLHeJGTtA4JMS",
              "evaluation_id": "68e41b85-12d8-4a2d-88de-f18af58b01f2",
              "evaluation_run_id": "ad8e8368-c69e-4636-9c64-217acc031c5c",
              "evaluation_run_started_at": "2025-12-12T01:28:32.736942Z",
              "evaluation_run_errored_at": "2025-12-12T01:33:01.577447Z",
              "evaluation_run_error_message": "The agent raised an exception while being evaluated: SyntaxError: Unexpected token 'export'\n\nTraceback:\nSyntaxError: Unexpected token 'export'\n    at compileSourceTextModule (node:internal/modules/esm/utils:317:16)\n    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:111:18)\n    at #translate (node:internal/modules/esm/loader:541:20)\n    at ModuleLoader.getModuleJobForRequire (node:internal/modules/esm/loader:494:33)\n    at #link (node:internal/modules/esm/module_job:447:34)\n    at new ModuleJobSync (node:internal/modules/esm/module_job:420:17)\n    at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:422:11)\n    at loadESMFromCJS (node:internal/modules/cjs/loader:1578:24)\n    at Module._compile (node:internal/modules/cjs/loader:1743:5)\n    at Object..js (node:internal/modules/cjs/loader:1893:10)"
            },
            {
              "agent_id": "14963fa6-8e58-4c38-8736-0bfd919e8f5e",
              "name": "Bingo",
              "version_num": 8,
              "validator_hotkey": "5G8iwBWxPjCfu9Fc3jFP37j1Ax5KypDDmUPUSoS9aWAsSCGT",
              "evaluation_id": "d5302092-c197-440e-9ebb-8b11f71cc658",
              "evaluation_run_id": "74dd101e-d106-4d5e-a9e8-7f34d01ff275",
              "evaluation_run_started_at": "2025-12-11T13:26:25.029145Z",
              "evaluation_run_errored_at": "2025-12-11T13:48:30.819257Z",
              "evaluation_run_error_message": "The agent raised an exception while being evaluated: SyntaxError: Illegal return statement\n\nTraceback:\nSyntaxError: Illegal return statement\n    at compileSourceTextModule (node:internal/modules/esm/utils:317:16)\n    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:111:18)\n    at #translate (node:internal/modules/esm/loader:541:20)\n    at ModuleLoader.getModuleJobForRequire (node:internal/modules/esm/loader:494:33)\n    at #link (node:internal/modules/esm/module_job:447:34)\n    at new ModuleJobSync (node:internal/modules/esm/module_job:420:17)\n    at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:422:11)\n    at loadESMFromCJS (node:internal/modules/cjs/loader:1578:24)\n    at Module._compile (node:internal/modules/cjs/loader:1743:5)\n    at Object..js (node:internal/modules/cjs/loader:1893:10)"
            },
            {
              "agent_id": "f272579a-dfa8-414e-8270-5e8160b6400e",
              "name": "mr.robot",
              "version_num": 0,
              "validator_hotkey": "5GgJptBaUiWwb8SQDinZ9rDQoVw47mgduXaCLHeJGTtA4JMS",
              "evaluation_id": "c837df73-049e-4396-b9b4-17979c16af09",
              "evaluation_run_id": "d9d073fa-c06a-47a6-a4c3-e336b62dfe60",
              "evaluation_run_started_at": "2025-12-11T11:58:09.681033Z",
              "evaluation_run_errored_at": "2025-12-11T12:21:22.817347Z",
              "evaluation_run_error_message": "The agent raised an exception while being evaluated: SyntaxError: Unexpected token 'export'\n\nTraceback:\nSyntaxError: Unexpected token 'export'\n    at compileSourceTextModule (node:internal/modules/esm/utils:317:16)\n    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:111:18)\n    at #translate (node:internal/modules/esm/loader:541:20)\n    at ModuleLoader.getModuleJobForRequire (node:internal/modules/esm/loader:494:33)\n    at #link (node:internal/modules/esm/module_job:447:34)\n    at new ModuleJobSync (node:internal/modules/esm/module_job:420:17)\n    at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:422:11)\n    at loadESMFromCJS (node:internal/modules/cjs/loader:1578:24)\n    at Module._compile (node:internal/modules/cjs/loader:1743:5)\n    at Object..js (node:internal/modules/cjs/loader:1893:10)"
            },
            {
              "agent_id": "f272579a-dfa8-414e-8270-5e8160b6400e",
              "name": "mr.robot",
              "version_num": 0,
              "validator_hotkey": "5FZ1BFw8eRMAFK5zwJdyefrsn51Lrm217WKbo3MmdFH65YRr",
              "evaluation_id": "c019a59e-3579-407a-a2a4-a3e64408774e",
              "evaluation_run_id": "b126cf4b-d687-4d21-ac10-58631c193604",
              "evaluation_run_started_at": "2025-12-11T11:58:02.296232Z",
              "evaluation_run_errored_at": "2025-12-11T12:20:59.542353Z",
              "evaluation_run_error_message": "The agent raised an exception while being evaluated: SyntaxError: Unexpected token 'export'\n\nTraceback:\nSyntaxError: Unexpected token 'export'\n    at compileSourceTextModule (node:internal/modules/esm/utils:317:16)\n    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:111:18)\n    at #translate (node:internal/modules/esm/loader:541:20)\n    at ModuleLoader.getModuleJobForRequire (node:internal/modules/esm/loader:494:33)\n    at #link (node:internal/modules/esm/module_job:447:34)\n    at new ModuleJobSync (node:internal/modules/esm/module_job:420:17)\n    at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:422:11)\n    at loadESMFromCJS (node:internal/modules/cjs/loader:1578:24)\n    at Module._compile (node:internal/modules/cjs/loader:1743:5)\n    at Object..js (node:internal/modules/cjs/loader:1893:10)"
            },
            {
              "agent_id": "9ba020c7-c90a-4d00-89d4-196a6256ec7e",
              "name": "WakeUp",
              "version_num": 5,
              "validator_hotkey": "screener-2-1",
              "evaluation_id": "8dad73cb-557e-4190-a775-fd8c8f83dfe1",
              "evaluation_run_id": "5abd6755-e4d8-458e-9891-bad332584491",
              "evaluation_run_started_at": "2025-12-11T07:26:03.533110Z",
              "evaluation_run_errored_at": "2025-12-11T07:49:33.686614Z",
              "evaluation_run_error_message": "The agent raised an exception while being evaluated: SyntaxError: Illegal continue statement: no surrounding iteration statement\n\nTraceback:\nSyntaxError: Illegal continue statement: no surrounding iteration statement\n    at compileSourceTextModule (node:internal/modules/esm/utils:317:16)\n    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:111:18)\n    at #translate (node:internal/modules/esm/loader:541:20)\n    at ModuleLoader.getModuleJobForRequire (node:internal/modules/esm/loader:494:33)\n    at #link (node:internal/modules/esm/module_job:447:34)\n    at new ModuleJobSync (node:internal/modules/esm/module_job:420:17)\n    at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:422:11)\n    at loadESMFromCJS (node:internal/modules/cjs/loader:1578:24)\n    at Module._compile (node:internal/modules/cjs/loader:1743:5)\n    at Object..js (node:internal/modules/cjs/loader:1893:10)"
            }
          ],
          "num_errors": 13
        },
        {
          "error_code": 1020,
          "error_message": "The agent timed out while being run",
          "recent_errored_agents": [
            {
              "agent_id": "c9588f05-3161-4eac-9815-7f5d2db522cd",
              "name": "Unique",
              "version_num": 2,
              "validator_hotkey": "5DP7gcGeTfGfmCzxVNCXQvWBxu58TrrkdikuHQNnGDYb7THU",
              "evaluation_id": "9cf03149-59d6-43ce-a8ae-87d517a27049",
              "evaluation_run_id": "09d71af3-99b0-4271-b86c-87937da349b2",
              "evaluation_run_started_at": "2025-12-11T20:43:25.394597Z",
              "evaluation_run_errored_at": "2025-12-11T21:09:11.659419Z",
              "evaluation_run_error_message": "The agent timed out while being run: The agent exceeded the timeout of 1500 seconds."
            },
            {
              "agent_id": "c42434dd-c183-4732-b3fe-1ee5f40abdb2",
              "name": "Upload",
              "version_num": 9,
              "validator_hotkey": "screener-2-1",
              "evaluation_id": "337f36eb-a501-4788-a073-fdfe8decbf1e",
              "evaluation_run_id": "e58e5ab2-2d7e-4e51-84ac-971f24e31fc8",
              "evaluation_run_started_at": "2025-12-11T16:29:43.620589Z",
              "evaluation_run_errored_at": "2025-12-11T16:54:55.245623Z",
              "evaluation_run_error_message": "The agent timed out while being run: The agent exceeded the timeout of 1500 seconds."
            },
            {
              "agent_id": "f7aa055b-f82c-4a50-8d1f-1d067d51fc76",
              "name": "ff",
              "version_num": 13,
              "validator_hotkey": "5G8iwBWxPjCfu9Fc3jFP37j1Ax5KypDDmUPUSoS9aWAsSCGT",
              "evaluation_id": "0f313f00-fdb7-4332-b8ce-fbba9ce36306",
              "evaluation_run_id": "7c46d2a5-8395-4573-8079-d4a723d24dc1",
              "evaluation_run_started_at": "2025-12-11T15:14:19.124760Z",
              "evaluation_run_errored_at": "2025-12-11T15:39:50.451982Z",
              "evaluation_run_error_message": "The agent timed out while being run: The agent exceeded the timeout of 1500 seconds."
            },
            {
              "agent_id": "7d043508-d887-4bae-b691-1057091adf2d",
              "name": "chappy",
              "version_num": 0,
              "validator_hotkey": "5Djyacas3eWLPhCKsS3neNSJonzfxJmD3gcrMTFDc4eHsn62",
              "evaluation_id": "dc3c83a8-5896-4678-9755-37cabc0a80ef",
              "evaluation_run_id": "0df2ac18-1f66-4ca9-b56b-dfa2d0f6b665",
              "evaluation_run_started_at": "2025-12-11T11:48:56.360981Z",
              "evaluation_run_errored_at": "2025-12-11T12:14:17.991489Z",
              "evaluation_run_error_message": "The agent timed out while being run: The agent exceeded the timeout of 1500 seconds."
            },
            {
              "agent_id": "7d043508-d887-4bae-b691-1057091adf2d",
              "name": "chappy",
              "version_num": 0,
              "validator_hotkey": "5HmkM6X1D3W3CuCSPuHhrbYyZNBy2aGAiZy9NczoJmtY25H7",
              "evaluation_id": "911d46d8-813b-4470-8116-9c35d71e510b",
              "evaluation_run_id": "3b44dab2-083c-4383-ab69-2611ad57ef71",
              "evaluation_run_started_at": "2025-12-11T11:47:30.409072Z",
              "evaluation_run_errored_at": "2025-12-11T12:12:44.531550Z",
              "evaluation_run_error_message": "The agent timed out while being run: The agent exceeded the timeout of 1500 seconds."
            }
          ],
          "num_errors": 36
        },
        {
          "error_code": 1030,
          "error_message": "The agent timed out while being evaluated",
          "recent_errored_agents": [
            {
              "agent_id": "98325ab3-3ff4-48c3-b4a2-a5cb83b1b9b9",
              "name": "Upload",
              "version_num": 7,
              "validator_hotkey": "5HmkM6X1D3W3CuCSPuHhrbYyZNBy2aGAiZy9NczoJmtY25H7",
              "evaluation_id": "ca82dead-5128-40b8-b735-633d8adac6e7",
              "evaluation_run_id": "1d19e9e3-0e37-4f83-a03b-dcd3a2203c07",
              "evaluation_run_started_at": "2025-12-10T14:13:49.704675Z",
              "evaluation_run_errored_at": "2025-12-10T14:34:08.736156Z",
              "evaluation_run_error_message": "The agent timed out while being evaluated: The agent exceeded the timeout of 600 seconds."
            }
          ],
          "num_errors": 1
        },
        {
          "error_code": 1040,
          "error_message": "The agent returned an invalid patch",
          "recent_errored_agents": [
            {
              "agent_id": "c6d0f160-f0f5-4b4f-8159-c2f3e8ce5653",
              "name": "Zeus",
              "version_num": 8,
              "validator_hotkey": "5F4U4P2j3ctdDS45naSUCxzYAHWTHarsY5JQdcRmMkc8UQZM",
              "evaluation_id": "4941368c-43d1-4085-b097-d0afe3ac72f0",
              "evaluation_run_id": "ffb71a15-ecd3-4adf-aeb8-a8167551af63",
              "evaluation_run_started_at": "2025-12-12T00:35:19.351523Z",
              "evaluation_run_errored_at": "2025-12-12T00:51:40.785464Z",
              "evaluation_run_error_message": "The agent returned an invalid patch: error: No valid patches in input (allow with \"--allow-empty\")"
            },
            {
              "agent_id": "bcbe3f72-a7f2-48bd-aa44-2430ff4254e0",
              "name": "hakuna-matata",
              "version_num": 4,
              "validator_hotkey": "5HmkM6X1D3W3CuCSPuHhrbYyZNBy2aGAiZy9NczoJmtY25H7",
              "evaluation_id": "6d780c14-a96f-4c50-9293-bb1a14ec47fd",
              "evaluation_run_id": "3b5681cb-a280-492d-b945-d4b6cae220f0",
              "evaluation_run_started_at": "2025-12-10T22:50:27.266444Z",
              "evaluation_run_errored_at": "2025-12-10T23:12:45.440147Z",
              "evaluation_run_error_message": "The agent returned an invalid patch: error: unrecognized input"
            },
            {
              "agent_id": "1d9716b7-17fa-4149-8d39-3de77e773174",
              "name": "maybe",
              "version_num": 0,
              "validator_hotkey": "5G8iwBWxPjCfu9Fc3jFP37j1Ax5KypDDmUPUSoS9aWAsSCGT",
              "evaluation_id": "cbd82252-d641-48bf-aa46-ac81279b5218",
              "evaluation_run_id": "7472b2ef-5232-472c-9e27-0e7613a29b7b",
              "evaluation_run_started_at": "2025-12-10T19:21:15.323168Z",
              "evaluation_run_errored_at": "2025-12-10T19:44:58.841752Z",
              "evaluation_run_error_message": "The agent returned an invalid patch: error: unrecognized input"
            },
            {
              "agent_id": "8f3725f0-40e2-4971-ac1e-ec0d784e0524",
              "name": "wct",
              "version_num": 3,
              "validator_hotkey": "5GgJptBaUiWwb8SQDinZ9rDQoVw47mgduXaCLHeJGTtA4JMS",
              "evaluation_id": "cce68372-2c5e-4629-8bab-b32b64bfb875",
              "evaluation_run_id": "537663d9-94fd-4936-9178-828ab64ac231",
              "evaluation_run_started_at": "2025-12-10T16:09:11.055443Z",
              "evaluation_run_errored_at": "2025-12-10T16:32:41.171192Z",
              "evaluation_run_error_message": "The agent returned an invalid patch: error: No valid patches in input (allow with \"--allow-empty\")"
            },
            {
              "agent_id": "dccb2044-89ba-4f24-b61d-e74962509973",
              "name": "hakuna-matata",
              "version_num": 3,
              "validator_hotkey": "screener-2-4",
              "evaluation_id": "a291b6ac-2606-45b5-9d02-7b0c4e649210",
              "evaluation_run_id": "3fc89321-7019-4220-aa88-a26dae494e29",
              "evaluation_run_started_at": "2025-12-10T07:33:57.374403Z",
              "evaluation_run_errored_at": "2025-12-10T07:56:49.418230Z",
              "evaluation_run_error_message": "The agent returned an invalid patch: error: No valid patches in input (allow with \"--allow-empty\")"
            }
          ],
          "num_errors": 8
        },
        {
          "error_code": 2030,
          "error_message": "An internal error occurred on the validator while the evaluation run was running the agent",
          "recent_errored_agents": [
            {
              "agent_id": "c42434dd-c183-4732-b3fe-1ee5f40abdb2",
              "name": "Upload",
              "version_num": 9,
              "validator_hotkey": "screener-2-2",
              "evaluation_id": "4dfd7080-46ef-4dfb-a881-ec4e21573c50",
              "evaluation_run_id": "e8c63c4b-1bae-4eca-b65d-7004342186b7",
              "evaluation_run_started_at": "2025-12-11T16:25:45.579744Z",
              "evaluation_run_errored_at": "2025-12-11T16:28:10.167323Z",
              "evaluation_run_error_message": "Platform crashed while running this evaluation"
            },
            {
              "agent_id": "6637b73d-f093-47aa-905e-51c20f3c63ce",
              "name": "wolf",
              "version_num": 2,
              "validator_hotkey": "5Djyacas3eWLPhCKsS3neNSJonzfxJmD3gcrMTFDc4eHsn62",
              "evaluation_id": "27059ad7-ba41-42f3-aad1-9c50e5c11ca5",
              "evaluation_run_id": "a7dd44ae-446e-4c76-b8f2-cc4a37ab9035",
              "evaluation_run_started_at": "2025-12-11T16:26:06.093208Z",
              "evaluation_run_errored_at": "2025-12-11T16:28:10.167323Z",
              "evaluation_run_error_message": "Platform crashed while running this evaluation"
            },
            {
              "agent_id": "dfb08885-8c65-4897-9a16-9f3a65729ea4",
              "name": "GoGo",
              "version_num": 5,
              "validator_hotkey": "5FZ1BFw8eRMAFK5zwJdyefrsn51Lrm217WKbo3MmdFH65YRr",
              "evaluation_id": "c5b0285d-7211-4ccf-8b34-1ef4d1ca0749",
              "evaluation_run_id": "319b4546-c98c-4579-bad9-cf57c0b73532",
              "evaluation_run_started_at": "2025-12-11T16:25:05.314995Z",
              "evaluation_run_errored_at": "2025-12-11T16:28:10.167323Z",
              "evaluation_run_error_message": "Platform crashed while running this evaluation"
            },
            {
              "agent_id": "6637b73d-f093-47aa-905e-51c20f3c63ce",
              "name": "wolf",
              "version_num": 2,
              "validator_hotkey": "5F4U4P2j3ctdDS45naSUCxzYAHWTHarsY5JQdcRmMkc8UQZM",
              "evaluation_id": "fb9bad0c-0b22-41df-9cf4-a7b8ae0e786b",
              "evaluation_run_id": "f35d8aaa-359c-4dfb-9cc8-81436ee9178f",
              "evaluation_run_started_at": "2025-12-11T16:25:56.744267Z",
              "evaluation_run_errored_at": "2025-12-11T16:28:10.167323Z",
              "evaluation_run_error_message": "Platform crashed while running this evaluation"
            },
            {
              "agent_id": "dfb08885-8c65-4897-9a16-9f3a65729ea4",
              "name": "GoGo",
              "version_num": 5,
              "validator_hotkey": "5HmkM6X1D3W3CuCSPuHhrbYyZNBy2aGAiZy9NczoJmtY25H7",
              "evaluation_id": "aee400a8-39ae-45af-9665-74fc4cbc0f27",
              "evaluation_run_id": "4bc15777-9c91-4c23-9401-102f5ab48df6",
              "evaluation_run_started_at": "2025-12-11T16:25:13.077765Z",
              "evaluation_run_errored_at": "2025-12-11T16:28:10.167323Z",
              "evaluation_run_error_message": "Platform crashed while running this evaluation"
            }
          ],
          "num_errors": 26
        },
        {
          "error_code": 3010,
          "error_message": "The platform was restarted while the evaluation run was initializing the agent",
          "recent_errored_agents": [
            {
              "agent_id": "0e74fd6c-9dd5-4c55-9599-1bda8c501eeb",
              "name": "whale",
              "version_num": 0,
              "validator_hotkey": "5Djyacas3eWLPhCKsS3neNSJonzfxJmD3gcrMTFDc4eHsn62",
              "evaluation_id": "aaad7cf9-ede2-4818-a433-2f11a48b1bcc",
              "evaluation_run_id": "7c43b526-4a90-4463-93c0-6707138ab0e0",
              "evaluation_run_started_at": "2025-12-11T18:59:34.697851Z",
              "evaluation_run_errored_at": "2025-12-11T19:00:00.920107Z",
              "evaluation_run_error_message": "The validator disconnected. Reason: Keyboard interrupt"
            },
            {
              "agent_id": "5501fac3-4b32-4438-99b5-71a4d0e15f48",
              "name": "LOVEYOU",
              "version_num": 2,
              "validator_hotkey": "5HmkM6X1D3W3CuCSPuHhrbYyZNBy2aGAiZy9NczoJmtY25H7",
              "evaluation_id": "500bd42c-4825-406a-9cab-4adda7d9f534",
              "evaluation_run_id": "157f98fb-a7bd-407b-a3f0-01505ac7ff36",
              "evaluation_run_started_at": "2025-12-11T13:01:45.884413Z",
              "evaluation_run_errored_at": "2025-12-11T13:06:07.536336Z",
              "evaluation_run_error_message": "The validator was disconnected because it did not send a heartbeat in 180 seconds."
            },
            {
              "agent_id": "820b6a39-7bcc-4639-8588-68b2855614f2",
              "name": "002",
              "version_num": 7,
              "validator_hotkey": "5Djyacas3eWLPhCKsS3neNSJonzfxJmD3gcrMTFDc4eHsn62",
              "evaluation_id": "91ed3ece-ce27-422e-9885-a45e7babac5a",
              "evaluation_run_id": "6d314f1c-f76a-4c10-9b6b-a298d337dc62",
              "evaluation_run_started_at": "2025-12-11T10:49:11.322282Z",
              "evaluation_run_errored_at": "2025-12-11T11:00:00.864641Z",
              "evaluation_run_error_message": "The validator disconnected. Reason: Keyboard interrupt"
            },
            {
              "agent_id": "72f4b9d5-8cc3-4fe0-8cde-be2d67b1a3f3",
              "name": "CIA",
              "version_num": 0,
              "validator_hotkey": "5Eho9y6iF5aTdKS28Awn2pKTd4dFsJ2o3shGtj1vjnLiaKJ1",
              "evaluation_id": "2eaa06bb-33d4-46f6-8d71-50c007ad17e1",
              "evaluation_run_id": "f6b84367-dec7-4e71-a5df-04987688bd80",
              "evaluation_run_started_at": "2025-12-11T07:50:13.434230Z",
              "evaluation_run_errored_at": "2025-12-11T08:08:23.951003Z",
              "evaluation_run_error_message": "The validator disconnected. Reason: Keyboard interrupt"
            },
            {
              "agent_id": "7f16f011-4e14-434f-95c4-708330c88443",
              "name": "tax",
              "version_num": 1,
              "validator_hotkey": "5Djyacas3eWLPhCKsS3neNSJonzfxJmD3gcrMTFDc4eHsn62",
              "evaluation_id": "df8ae458-fe3f-4b75-a252-60b6e436766f",
              "evaluation_run_id": "6a87a4fd-d1cb-402f-a590-65b24675739a",
              "evaluation_run_started_at": "2025-12-10T22:38:49.729042Z",
              "evaluation_run_errored_at": "2025-12-10T23:00:00.919540Z",
              "evaluation_run_error_message": "The validator disconnected. Reason: Keyboard interrupt"
            }
          ],
          "num_errors": 13
        }
      ],
      "token_distribution": [
        {
          "model": "deepseek-ai/DeepSeek-V3-0324",
          "num_input_tokens": 537308,
          "num_output_tokens": 47604
        },
        {
          "model": "moonshotai/Kimi-K2-Instruct",
          "num_input_tokens": 28085975,
          "num_output_tokens": 4213859
        },
        {
          "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
          "num_input_tokens": 74089001,
          "num_output_tokens": 19397658
        },
        {
          "model": "zai-org/GLM-4.5-FP8",
          "num_input_tokens": 1993746,
          "num_output_tokens": 242574
        },
        {
          "model": "zai-org/GLM-4.6-FP8",
          "num_input_tokens": 48288433,
          "num_output_tokens": 3098183
        }
      ],
      "fastest_agents": [
        {
          "agent_id": "c4dc37d6-742d-4b6d-9316-4a2eb0f25c89",
          "name": "clean",
          "version_num": 34,
          "evaluation_id": "9493227c-ec75-43e3-abce-34ba1c6b3158",
          "evaluation_run_id": "79b4cf3d-5174-4c0b-9184-cc7ac98bba8a",
          "evaluation_run_started_at": "2025-12-11T08:15:10.520368Z",
          "evaluation_run_finished_at": "2025-12-11T08:16:19.925024Z"
        },
        {
          "agent_id": "e4652431-098b-4f69-bd3b-6687b38b52f0",
          "name": "blahblah",
          "version_num": 14,
          "evaluation_id": "fa295a31-54bf-4955-ba56-40393c73c870",
          "evaluation_run_id": "772812df-7cc5-41ae-a992-d356737e27a4",
          "evaluation_run_started_at": "2025-12-11T21:47:47.777349Z",
          "evaluation_run_finished_at": "2025-12-11T21:50:12.475578Z"
        },
        {
          "agent_id": "b3ea2006-a56b-4385-9401-66349583995a",
          "name": "Eternal",
          "version_num": 3,
          "evaluation_id": "f0c216a3-9a66-430f-a6ea-23f3c0987c83",
          "evaluation_run_id": "20d4e6f5-3a03-42a4-86b4-cc6d0eb8b3ce",
          "evaluation_run_started_at": "2025-12-11T17:41:23.556170Z",
          "evaluation_run_finished_at": "2025-12-11T17:44:05.909685Z"
        },
        {
          "agent_id": "bf641434-c956-4561-89ca-107ea13bda2c",
          "name": "GOAT",
          "version_num": 4,
          "evaluation_id": "5113ac91-59f0-48cb-9f0b-cb9569e0b828",
          "evaluation_run_id": "59eded3c-dc12-49b0-84b7-b94341b919f6",
          "evaluation_run_started_at": "2025-12-11T11:10:34.095696Z",
          "evaluation_run_finished_at": "2025-12-11T11:13:24.289124Z"
        },
        {
          "agent_id": "1e31fc10-4e34-48e3-b562-dcabb8e7472c",
          "name": "effort",
          "version_num": 18,
          "evaluation_id": "ef29140c-ec50-4110-bef8-1dfea1392b65",
          "evaluation_run_id": "36c7d927-dd2a-43a4-a55a-9d36df1fc93f",
          "evaluation_run_started_at": "2025-12-11T01:52:01.015075Z",
          "evaluation_run_finished_at": "2025-12-11T01:55:27.578517Z"
        }
      ]
    },
    {
      "problem_name": "astropy__astropy-14309",
      "problem_suite_name": "swebench_verified",
      "problem_difficulty": "easy",
      "total_num_evaluation_runs": 247,
      "num_finished_evaluation_runs": 220,
      "num_finished_passed_evaluation_runs": 215,
      "num_finished_failed_evaluation_runs": 5,
      "num_errored_evaluation_runs": 25,
      "pass_rate": 0.9772727272727273,
      "average_time": 976.0833424653061,
      "average_cost_usd": 0.9802756323886638,
      "in_screener_1_set_group": false,
      "in_screener_2_set_group": true,
      "in_validator_set_group": false,
      "tests": [
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_hdu_3[third]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_python_to_tdisp[7.3f-F7.3]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_write_drop_nonstandard_units[QTable]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_masked_nan[False]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_warning[0]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col16]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_mask_null_on_read",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[Table-name_col2]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_3[3]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_in_last_hdu[0]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_round_trip_masked_table_serialize_mask[names]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col15]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_unit_warnings_read_write",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col4]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col2]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_parse_tdisp_format[F6.2-format_return1]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_simple",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col3]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_is_fits_gh_14305",
          "category": "fail_to_pass",
          "num_runs": 220,
          "num_passed": 215,
          "num_failed": 5,
          "pass_rate": 0.9772727272727273
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_1[first]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_hdu_missing[second]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_hdu_1[first]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[Table-name_col6]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_masked_serialize_data_mask",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col18]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_python_to_tdisp[%10s-A10]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[Table-name_col8]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_oned_single_element",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_missing[3]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col8]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_1[1]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[Table-name_col7]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_write_overwrite",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_read_with_unit_aliases[QTable]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[Table-name_col17]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_character_as_bytes[True]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_as_one[Table]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_hdu_0",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_single_hdu[None]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_in_last_hdu[1]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_as_one[QTable]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col1]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_python_to_tdisp[3d-I3]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[Table-name_col4]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_3[third]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col13]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_in_last_hdu[1]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_memmap",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_parse_tdisp_format[B5.10-format_return2]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_in_last_hdu[0]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[Table-name_col0]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_missing[]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fortran_to_python_format[G15.4E2-{:15.4g}]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_write_drop_nonstandard_units[Table]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col12]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_logical_python_to_tdisp",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_single_hdu[first]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_hdu_missing[1]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_hdu_missing[2]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_meta_not_modified",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_warning[2]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_0",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_with_units[QTable]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_4",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_missing[1]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fortran_to_python_format[Z5.10-{:5x}]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_scale_error",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_python_to_tdisp[%5.3g-G5.3]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_round_trip_masked_table_serialize_mask[class]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col17]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_with_units[Table]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_masked_nan[True]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col7]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_mask_nans_on_read",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_with_custom_units_qtable",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[Table-name_col1]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_parse_tdisp_format[E10.5E3-format_return3]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_in_last_hdu[third]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[Table-name_col5]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col9]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_python_to_tdisp[{:3d}-I3]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_convert_comment_convention",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_missing[second]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_mask_str_on_read",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_with_format[QTable]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_round_trip_masked_table_serialize_mask[set_cols]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_read_with_unit_aliases[Table]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_parse_tdisp_format[EN10.5-format_return0]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_bool_column",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_hdu_missing[]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_single_table[first]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_single_table[None]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_python_to_tdisp[{:7.4f}-F7.4]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_unicode_column",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[Table-name_col18]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_2[second]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_info_attributes_with_no_mixins",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[Table-name_col15]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_hdu_1[1]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_single_hdu[1]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_parse_tdisp_format[A21-format_return4]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[Table-name_col3]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_hdu_warning[0]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_2[2]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_hdu_warning[third]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_missing[2]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col6]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_simple_noextension",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_simple_meta",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_in_last_hdu[third]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_single_table[1]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col10]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_with_format[Table]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_read_with_nonstandard_units",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_masked",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_hdu_missing[3]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fortran_to_python_format[I6.5-{:6d}]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_python_to_tdisp[%.4f-F13.4]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col11]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[Table-name_col13]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_python_to_tdisp[{:>4}-A4]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_qtable_to_table",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_with_hdu_warning[third]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col0]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_masking_regression_1795",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col5]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_hdu_3[3]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_simple_meta_conflicting",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_hdu_2[second]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_simple_pathlib",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_read_from_fileobj",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fortran_to_python_format[L8-{:>8}]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_hdu_2[2]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_character_as_bytes[False]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestMultipleHDU::test_read_from_hdulist_with_hdu_warning[2]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::TestSingleTable::test_write_append",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[QTable-name_col14]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[Table-name_col14]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fortran_to_python_format[E20.7-{:20.7e}]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        },
        {
          "name": "astropy/io/fits/tests/test_connect.py::test_fits_mixins_per_column[Table-name_col16]",
          "category": "pass_to_pass",
          "num_runs": 220,
          "num_passed": 219,
          "num_failed": 1,
          "pass_rate": 0.9954545454545455
        }
      ],
      "error_code_distribution": [
        {
          "error_code": 1020,
          "error_message": "The agent timed out while being run",
          "recent_errored_agents": [
            {
              "agent_id": "2649ef64-89e4-4c13-8340-a4c469c4d575",
              "name": "LOVEYOU",
              "version_num": 1,
              "validator_hotkey": "screener-2-3",
              "evaluation_id": "00ff08bd-af32-4b21-9374-1920e7f93a17",
              "evaluation_run_id": "c4a70f0d-78d5-4338-bd3a-57d9fda5a32a",
              "evaluation_run_started_at": "2025-12-10T03:26:35.352653Z",
              "evaluation_run_errored_at": "2025-12-10T03:51:52.912674Z",
              "evaluation_run_error_message": "The agent timed out while being run: The agent exceeded the timeout of 1500 seconds."
            },
            {
              "agent_id": "2ac8f392-95ab-4873-aa2a-03ef57aaa2f6",
              "name": "test",
              "version_num": 0,
              "validator_hotkey": "screener-2-4",
              "evaluation_id": "f1e27265-ddea-44fd-a486-1d5b3f04a140",
              "evaluation_run_id": "0fa736ff-998f-4895-a591-6879d80626b9",
              "evaluation_run_started_at": "2025-12-10T02:36:38.680006Z",
              "evaluation_run_errored_at": "2025-12-10T03:01:56.113441Z",
              "evaluation_run_error_message": "The agent timed out while being run: The agent exceeded the timeout of 1500 seconds."
            }
          ],
          "num_errors": 2
        },
        {
          "error_code": 1040,
          "error_message": "The agent returned an invalid patch",
          "recent_errored_agents": [
            {
              "agent_id": "7e3bf24a-4741-445d-a857-45a8450e4f43",
              "name": "ridges",
              "version_num": 0,
              "validator_hotkey": "screener-2-4",
              "evaluation_id": "104174a5-3ce8-4cef-9093-00e726e12699",
              "evaluation_run_id": "1678515b-9310-4342-a568-7a43cada65a6",
              "evaluation_run_started_at": "2025-12-11T04:09:57.215331Z",
              "evaluation_run_errored_at": "2025-12-11T04:10:32.798730Z",
              "evaluation_run_error_message": "The agent returned an invalid patch: error: No valid patches in input (allow with \"--allow-empty\")"
            },
            {
              "agent_id": "b7abf603-ebb7-4c3d-b98b-d26e6b2bb8db",
              "name": "GMP",
              "version_num": 1,
              "validator_hotkey": "screener-2-3",
              "evaluation_id": "85c64567-b8f2-4e8b-af29-82933bf058f6",
              "evaluation_run_id": "fcf8764f-1465-4571-a411-a49fe8f7a56b",
              "evaluation_run_started_at": "2025-12-10T21:24:16.578428Z",
              "evaluation_run_errored_at": "2025-12-10T21:26:54.648959Z",
              "evaluation_run_error_message": "The agent returned an invalid patch: error: No valid patches in input (allow with \"--allow-empty\")"
            },
            {
              "agent_id": "0d3816ad-85ba-48b2-bb34-917016a40f56",
              "name": "NANO",
              "version_num": 31,
              "validator_hotkey": "screener-2-4",
              "evaluation_id": "8b96c28a-7646-4b8f-bea3-f512eddbd24f",
              "evaluation_run_id": "6f7c04e7-ef34-4a2e-9f78-b4499a987887",
              "evaluation_run_started_at": "2025-12-10T12:22:08.858086Z",
              "evaluation_run_errored_at": "2025-12-10T12:44:37.133646Z",
              "evaluation_run_error_message": "The agent returned an invalid patch: error: No valid patches in input (allow with \"--allow-empty\")"
            },
            {
              "agent_id": "983933ae-1082-4295-98f6-d13490357b14",
              "name": "one",
              "version_num": 6,
              "validator_hotkey": "screener-2-2",
              "evaluation_id": "2d75715a-ee43-4af1-901c-f21ec1f24ecb",
              "evaluation_run_id": "20fefd88-adf0-4ad5-854f-b86d1bee9ac7",
              "evaluation_run_started_at": "2025-12-10T12:01:16.223631Z",
              "evaluation_run_errored_at": "2025-12-10T12:23:14.368812Z",
              "evaluation_run_error_message": "The agent returned an invalid patch: error: No valid patches in input (allow with \"--allow-empty\")"
            },
            {
              "agent_id": "6e55ddb8-0680-42cf-b120-3c46c4dee139",
              "name": "uv",
              "version_num": 8,
              "validator_hotkey": "screener-2-2",
              "evaluation_id": "dde49879-330b-4ce5-832a-fda6c5554321",
              "evaluation_run_id": "fdc888ab-adf2-46b5-911a-bdfff0db8301",
              "evaluation_run_started_at": "2025-12-10T05:09:25.799538Z",
              "evaluation_run_errored_at": "2025-12-10T05:32:57.443283Z",
              "evaluation_run_error_message": "The agent returned an invalid patch: error: No valid patches in input (allow with \"--allow-empty\")"
            }
          ],
          "num_errors": 16
        },
        {
          "error_code": 2030,
          "error_message": "An internal error occurred on the validator while the evaluation run was running the agent",
          "recent_errored_agents": [
            {
              "agent_id": "d2f744f0-6d0a-407d-a221-b669cebbe758",
              "name": "First",
              "version_num": 5,
              "validator_hotkey": "screener-2-1",
              "evaluation_id": "7ef49202-49c7-48eb-b410-29d36c100209",
              "evaluation_run_id": "0beaf246-d18d-4ae6-96de-6119eec6e424",
              "evaluation_run_started_at": "2025-12-11T16:24:51.628834Z",
              "evaluation_run_errored_at": "2025-12-11T16:28:10.167323Z",
              "evaluation_run_error_message": "Platform crashed while running this evaluation"
            },
            {
              "agent_id": "c42434dd-c183-4732-b3fe-1ee5f40abdb2",
              "name": "Upload",
              "version_num": 9,
              "validator_hotkey": "screener-2-2",
              "evaluation_id": "4dfd7080-46ef-4dfb-a881-ec4e21573c50",
              "evaluation_run_id": "4c2e88a6-41c3-4fc1-bc8d-2269552e6722",
              "evaluation_run_started_at": "2025-12-11T16:25:45.579744Z",
              "evaluation_run_errored_at": "2025-12-11T16:28:10.167323Z",
              "evaluation_run_error_message": "Platform crashed while running this evaluation"
            },
            {
              "agent_id": "0fa66124-705a-4696-bdf6-24e6bbe7edce",
              "name": "sn62",
              "version_num": 3,
              "validator_hotkey": "screener-2-2",
              "evaluation_id": "d677ff94-985f-4d0f-a796-e49b296d4b27",
              "evaluation_run_id": "aaece718-31e7-45c2-b045-e73bdec66576",
              "evaluation_run_started_at": "2025-12-10T23:41:59.013108Z",
              "evaluation_run_errored_at": "2025-12-10T23:50:04.882174Z",
              "evaluation_run_error_message": "Platform crashed while running this evaluation"
            },
            {
              "agent_id": "6dfd905d-c756-4b74-9c0a-cc3f97eedcf8",
              "name": "miracle",
              "version_num": 2,
              "validator_hotkey": "screener-2-1",
              "evaluation_id": "3fe06063-87a1-4213-869b-d4551698b52e",
              "evaluation_run_id": "ba4a95e2-1e88-4591-bb6e-c1385adea50c",
              "evaluation_run_started_at": "2025-12-10T23:41:16.225871Z",
              "evaluation_run_errored_at": "2025-12-10T23:50:04.882174Z",
              "evaluation_run_error_message": "Platform crashed while running this evaluation"
            },
            {
              "agent_id": "98325ab3-3ff4-48c3-b4a2-a5cb83b1b9b9",
              "name": "Upload",
              "version_num": 7,
              "validator_hotkey": "screener-2-2",
              "evaluation_id": "bec1c04a-52fa-4729-8149-6482dea0d19d",
              "evaluation_run_id": "8ab97992-3aed-44a1-838a-308b979e7844",
              "evaluation_run_started_at": "2025-12-10T04:15:39.111061Z",
              "evaluation_run_errored_at": "2025-12-10T04:18:25.157782Z",
              "evaluation_run_error_message": "Platform crashed while running this evaluation"
            }
          ],
          "num_errors": 7
        }
      ],
      "token_distribution": [
        {
          "model": "deepseek-ai/DeepSeek-V3-0324",
          "num_input_tokens": 996288,
          "num_output_tokens": 29843
        },
        {
          "model": "moonshotai/Kimi-K2-Instruct",
          "num_input_tokens": 43124920,
          "num_output_tokens": 1583916
        },
        {
          "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
          "num_input_tokens": 25948412,
          "num_output_tokens": 921959
        },
        {
          "model": "zai-org/GLM-4.5-FP8",
          "num_input_tokens": 3673645,
          "num_output_tokens": 119520
        },
        {
          "model": "zai-org/GLM-4.6-FP8",
          "num_input_tokens": 57354732,
          "num_output_tokens": 1354842
        }
      ],
      "fastest_agents": [
        {
          "agent_id": "00aabb5a-85aa-4bac-9b57-4d3ae48c4f42",
          "name": "king",
          "version_num": 0,
          "evaluation_id": "9691890a-d360-4118-a85f-7dbd3819a6cf",
          "evaluation_run_id": "dd8828fa-ec50-4201-852b-7e61673e54e8",
          "evaluation_run_started_at": "2025-12-10T20:58:58.293095Z",
          "evaluation_run_finished_at": "2025-12-10T21:03:33.161810Z"
        },
        {
          "agent_id": "a1582955-4a42-42bb-bc3b-8758973ce8a8",
          "name": "toronto",
          "version_num": 11,
          "evaluation_id": "5684c781-fc60-411b-83cb-bbce0b244c35",
          "evaluation_run_id": "663b8e91-3492-4a25-a083-1a1fa5d271f3",
          "evaluation_run_started_at": "2025-12-10T07:29:16.070106Z",
          "evaluation_run_finished_at": "2025-12-10T07:34:04.975154Z"
        },
        {
          "agent_id": "43bb811b-0303-489d-927f-39bad06ea1e5",
          "name": "kraken",
          "version_num": 6,
          "evaluation_id": "6c87f87d-000b-4df8-86d6-7f23c58a97e9",
          "evaluation_run_id": "2d6c4730-f047-4dcf-88a5-1429c2cdf433",
          "evaluation_run_started_at": "2025-12-10T06:23:20.129025Z",
          "evaluation_run_finished_at": "2025-12-10T06:28:34.257179Z"
        },
        {
          "agent_id": "7d043508-d887-4bae-b691-1057091adf2d",
          "name": "chappy",
          "version_num": 0,
          "evaluation_id": "54f24e75-b791-4404-9909-41ec8e27f871",
          "evaluation_run_id": "325dcf36-f099-467f-86b0-e4f8eacd210a",
          "evaluation_run_started_at": "2025-12-11T11:20:29.419081Z",
          "evaluation_run_finished_at": "2025-12-11T11:25:58.570578Z"
        },
        {
          "agent_id": "2f3977e8-3027-4a4a-a21e-1c41638dc7e8",
          "name": "Virus",
          "version_num": 0,
          "evaluation_id": "908586ef-05c8-41d8-8782-9d4f2d889a60",
          "evaluation_run_id": "2eaba1ad-6db4-414f-980f-0783b8953519",
          "evaluation_run_started_at": "2025-12-10T16:18:54.927285Z",
          "evaluation_run_finished_at": "2025-12-10T16:24:28.826614Z"
        }
      ]
    }
  ],
  "problem_set_id": 8,
  "problem_set_created_at": "2025-12-09T22:52:48.832216Z"
}
```
</details>