### PR TITLE
Re-fix tests solutions for unpatched Polyglots

### DIFF
--- a/evaluator/datasets/polyglot_py_unpatched/alphametics/tests.py
+++ b/evaluator/datasets/polyglot_py_unpatched/alphametics/tests.py
@@ -64,7 +64,6 @@ class AlphameticsTest(unittest.TestCase):
         )
 
     # See https://github.com/exercism/python/pull/1358
-    @unittest.skip("extra-credit")
     def test_puzzle_with_ten_letters_and_199_addends(self):
         """This test may take a long time to run. Please be patient when running it."""
         puzzle = (

--- a/evaluator/datasets/polyglot_py_unpatched/error-handling/tests.py
+++ b/evaluator/datasets/polyglot_py_unpatched/error-handling/tests.py
@@ -1,8 +1,33 @@
 import unittest
 
 import main as er
-from test_utils import FileLike
 
+class FileLike:
+    def __init__(self, fail_something=True):
+        self.is_open = False
+        self.was_open = False
+        self.did_something = False
+        self.fail_something = fail_something
+
+    def open(self):
+        self.was_open = False
+        self.is_open = True
+
+    def close(self):
+        self.is_open = False
+        self.was_open = True
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def do_something(self):
+        self.did_something = True
+        if self.fail_something:
+            raise Exception("Failed while doing something")
 
 class ErrorHandlingTest(unittest.TestCase):
     def test_throw_exception(self):

--- a/evaluator/datasets/polyglot_py_unpatched/grep/tests.py
+++ b/evaluator/datasets/polyglot_py_unpatched/grep/tests.py
@@ -47,7 +47,7 @@ def open_mock(fname, *args, **kwargs):
         )
 
 
-@mock.patch("grep.open", name="open", side_effect=open_mock, create=True)
+@mock.patch("main.open", name="open", side_effect=open_mock, create=True)
 @mock.patch("io.StringIO", name="StringIO", wraps=io.StringIO)
 class GrepTest(unittest.TestCase):
     # Test grepping a single file

--- a/evaluator/datasets/polyglot_py_unpatched/hangman/tests.py
+++ b/evaluator/datasets/polyglot_py_unpatched/hangman/tests.py
@@ -1,6 +1,6 @@
 import unittest
 
-import main
+import main as hangman
 from main import Hangman
 
 

--- a/evaluator/datasets/polyglot_py_unpatched/sgf-parsing/solution.py
+++ b/evaluator/datasets/polyglot_py_unpatched/sgf-parsing/solution.py
@@ -1,17 +1,22 @@
 """Parse an SGF tree."""
-from __future__ import annotations
-
 import collections
-import dataclasses
 import string
 
 
-@dataclasses.dataclass
 class SgfTree:
     """SGF Node."""
 
-    properties: dict[str, str] = dataclasses.field(default_factory=dict)
-    children: list[SgfTree] = dataclasses.field(default_factory=list)
+    def __init__(self, properties=None, children=None):
+        self.properties = properties if properties is not None else {}
+        self.children = children if children is not None else []
+
+    def __eq__(self, other):
+        if not isinstance(other, SgfTree):
+            return False
+        return self.properties == other.properties and self.children == other.children
+
+    def __ne__(self, other):
+        return not self == other
 
 
 def parse_property_vals(sgf: str, idx: int) -> tuple[int, list[str]]:

--- a/evaluator/datasets/polyglot_py_unpatched/yacht/tests.py
+++ b/evaluator/datasets/polyglot_py_unpatched/yacht/tests.py
@@ -3,7 +3,7 @@
 # File last updated on 2023-07-19
 
 import unittest
-import main
+import main as yacht
 
 
 class YachtTest(unittest.TestCase):


### PR DESCRIPTION
Changes taken from [here](https://github.com/ridgesai/ridges/pull/256) and [here](https://github.com/ridgesai/ridges/pull/223) and this commit 1a7b1dbfc1f4a7611a5d4ab6f5848ebe798638f0

To run:
```bash
v run -m test_agent --include-solutions --include-tests --polyglot-unpatched --inference-url http://192.168.1.57:1234 --agent-path ~/agents/test_agent.py test-problem-set all-polyglot-py >re-patch-polyglot.txt
```