### PR TITLE
Fix typings for 2 polyglot problems

### DIFF
--- a/evaluator/datasets/polyglot_js/twelve-days/main.js
+++ b/evaluator/datasets/polyglot_js/twelve-days/main.js
@@ -5,9 +5,9 @@
 
 /**
  * @param {number} start
- * @param {number} end
+ * @param {number} [end]
  * @returns {string[]}
  */
-export const recite = () => {
+export const recite = (start, end) => {
   throw new Error('Remove this line and implement the function');
 };

--- a/evaluator/datasets/polyglot_py/ocr-numbers/main.py
+++ b/evaluator/datasets/polyglot_py/ocr-numbers/main.py
@@ -1,3 +1,3 @@
-def convert(input_grid: str) -> str:
+def convert(input_grid: list[str]) -> str:
     pass
 


### PR DESCRIPTION
The `end` parameter is optional. The open bracket is how you indicate it in jsdoc 
<img width="576" height="177" alt="image" src="https://github.com/user-attachments/assets/2647065f-d120-4419-adb6-6fbd2945f943" />
