### PR TITLE
new approval endpoint/query

### DIFF
--- a/api/endpoints/scoring.py
+++ b/api/endpoints/scoring.py
@@ -7,7 +7,7 @@ from utils.ttl import ttl_cache
 from typing import Dict, Optional
 from models.evaluation_set import EvaluationSetGroup
 from utils.bittensor import check_if_hotkey_is_registered
-from queries.scores import get_weight_receiving_agent_hotkey
+from queries.scores import get_weight_receiving_agent_hotkey, get_weight_receiving_agent_info
 from queries.evaluation_set import get_latest_set_id, get_set_created_at
 from queries.statistics import get_average_score_per_evaluation_set_group, get_average_wait_time_per_evaluation_set_group
 
@@ -36,6 +36,16 @@ async def weights() -> Dict[str, float]:
     # owner hotkey (to burn).
     return {config.OWNER_HOTKEY: 1.0}
 
+@router.get("/approval-info")
+async def approval_info() -> Dict[str, str | float]:
+    if config.BURN:
+        return {"hotkey": config.OWNER_HOTKEY, "agent_id": None, "weight": 1.0}
+    
+    weight_receiving_agent_info = await get_weight_receiving_agent_info()
+    if weight_receiving_agent_info:
+        return {"hotkey": weight_receiving_agent_info["miner_hotkey"], "agent_id": weight_receiving_agent_info["agent_id"], "weight": 1.0}
+    
+    return {"hotkey": config.OWNER_HOTKEY, "agent_id": None, "weight": 1.0}
 
 
 # /scoring/screener-info

--- a/queries/scores.py
+++ b/queries/scores.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Dict
 
 from utils.database import db_operation, DatabaseConnection
 
@@ -23,3 +23,23 @@ async def get_weight_receiving_agent_hotkey(conn: DatabaseConnection) -> Optiona
     if current_leader is None or "miner_hotkey" not in current_leader:
         return None
     return current_leader["miner_hotkey"]
+
+async def get_weight_receiving_agent_info(conn: DatabaseConnection) -> Optional[Dict[str, str]]:
+    current_leader = await conn.fetchrow(
+        """
+        SELECT 
+            ass.miner_hotkey AS miner_hotkey,
+            ass.agent_id AS agent_id
+        FROM agent_scores ass
+        WHERE 
+            ass.approved 
+            AND ass.approved_at <= NOW() 
+            AND ass.set_id = (SELECT MAX(set_id) FROM evaluation_sets)
+            AND ass.agent_id NOT IN (SELECT agent_id FROM benchmark_agent_ids)
+        ORDER BY ass.final_score DESC, ass.created_at ASC
+        LIMIT 1
+    """
+    )
+    if current_leader is None or "miner_hotkey" not in current_leader or "agent_id" not in current_leader:
+        return None
+    return current_leader


### PR DESCRIPTION
- added new endpoint `/scoring/approval-info`
- added new query that gets approved agents hotkey and id for this endpoint
- the new endpoint returns agent_id, hotkey, and weight in dictionary