### PR TITLE
[feat] update validator-side inference proxy to handle cloudflare SSL

### DIFF
--- a/evaluator/sandbox/proxy/nginx.conf.template
+++ b/evaluator/sandbox/proxy/nginx.conf.template
@@ -1,6 +1,9 @@
 events {}
 
 http {
+    # Use a public DNS resolver for upstream name resolution
+    resolver 1.1.1.1 1.0.0.1 ipv6=off;
+
     server {
         listen 80;
 
@@ -14,6 +17,10 @@ http {
             proxy_connect_timeout 300s;
             proxy_send_timeout 300s;
             proxy_read_timeout 300s;
+
+            # Ensure TLS SNI to Cloudflare/origin matches the hostname
+            proxy_ssl_server_name on;
+            proxy_ssl_name $GATEWAY_HOST;
         }
     }
 }


### PR DESCRIPTION
Was getting an error with the SSL handshake when trying to proxy via Cloudflare 
`sandbox -(http)->  sandbox-proxy -(TLS)-> Cloudflare -(TLS)-> Inference server`
Changing the nginx conf to:  

 A. use cloudflare DNS for faster changes
 B. pass the expected domain to cloudflare via SNI

B is the main concern