### PR TITLE
Feature: Improve local development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ## Development Guide
 
+### Requirements
+
+- Python 3.12+
+- Docker (for running dependencies like Postgres and S3 locally)
+- UV (for managing Python dependencies)
+
 ### Setting up the development environment
 
 Install dependencies (including dev tools):
@@ -20,4 +26,28 @@ To run the hooks manually against all files at any time:
 
 ```bash
 uv run pre-commit run --all-files
+```
+
+### Running the services locally
+
+1. Start the dependencies (Postgres and Adobe S3 mock) using docker compose. Make sure to update the `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` environment variables in `docker-compose.yml` before starting the services.
+
+```bash
+docker compose up -d
+```
+
+2. For the platform API, create a `.env` file in the `api/` directory based on the provided `.env.example` and fill in the required environment variables.
+
+3. Start the API:
+
+```bash
+python -m api.src.main
+```
+
+4. For the validator, create a `.env` file in the `validator/` directory based on the provided `.env.example` and fill in the required environment variables. Depending on the "MODE" you might start a "Screener" or a "Validator"
+
+5. Start the validator:
+
+```bash
+python -m validator.src.main
 ```

--- a/README.md
+++ b/README.md
@@ -30,23 +30,17 @@ uv run pre-commit run --all-files
 
 ### Running the services locally
 
-1. Start the dependencies (Postgres and Adobe S3 mock) using docker compose. Make sure to update the `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` environment variables in `docker-compose.yml` before starting the services.
+In order to run the services locally you can use the provided `docker-compose.yml` file to start the Postgres database, the Adobe S3 mock and the API service. 
+
+Before starting the services, make sure to update the `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` environment variables in `docker-compose.yml` with your desired values.
+
+You also need to create a `.env` file in the `api/` directory based on the provided `.env.example` and fill in the required environment variables.
 
 ```bash
 docker compose up -d
 ```
 
-2. For the platform API, create a `.env` file in the `api/` directory based on the provided `.env.example` and fill in the required environment variables.
-
-3. Start the API:
-
-```bash
-python -m api.src.main
-```
-
-4. For the validator, create a `.env` file in the `validator/` directory based on the provided `.env.example` and fill in the required environment variables. Depending on the "MODE" you might start a "Screener" or a "Validator"
-
-5. Start the validator:
+For the validator, create a `.env` file in the `validator/` directory based on the provided `.env.example` and fill in the required environment variables. Depending on the "MODE" env variable value you might start a "Screener" or a "Validator"
 
 ```bash
 python -m validator.src.main

--- a/api/.env.example
+++ b/api/.env.example
@@ -26,6 +26,7 @@ AWS_REGION=
 
 
 S3_BUCKET_NAME=
+S3_ENDPOINT_URL= # Optional, used for testing with local S3 emulators or connecting to S3-compatible services
 
 
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY . .
+RUN uv sync --frozen --no-dev
+
+CMD ["uv", "run", "-m", "api.src.main"]

--- a/api/config.py
+++ b/api/config.py
@@ -86,6 +86,11 @@ S3_BUCKET_NAME = os.getenv("S3_BUCKET_NAME")
 if not S3_BUCKET_NAME:
     logger.fatal("S3_BUCKET_NAME is not set in .env")
 
+# Load S3 endpoint URL (optional, used for testing with local S3 emulators or connecting to S3-compatible services)
+S3_ENDPOINT_URL = os.getenv("S3_ENDPOINT_URL")
+if not S3_ENDPOINT_URL:
+    logger.debug("S3_ENDPOINT_URL is not set in .env")
+
 
 # Load database configuration
 DATABASE_USERNAME = os.getenv("DATABASE_USERNAME")
@@ -214,6 +219,8 @@ logger.info("-------------------------")
 
 logger.info(f"S3 Bucket Name: {S3_BUCKET_NAME}")
 logger.info("-------------------------")
+
+logger.info(f"S3 Endpoint URL: {S3_ENDPOINT_URL if S3_ENDPOINT_URL else 'Not set, using default AWS S3 endpoint'}")
 
 logger.info(f"Database Username: {DATABASE_USERNAME}")
 logger.info(f"Database Host: {DATABASE_HOST}")

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -20,7 +20,9 @@ from api.endpoints.statistics import router as statistics_router
 # NEW fixed endpoints
 from api.endpoints.validator import router as validator_router
 from api.loops.fetch_metagraph import fetch_metagraph_loop
-from api.loops.validator_heartbeat_timeout import validator_heartbeat_timeout_loop
+from api.loops.validator_heartbeat_timeout import (
+    validator_heartbeat_timeout_loop,
+)
 from api.src.endpoints.upload import router as upload_router
 from queries.evaluation import set_all_unfinished_evaluation_runs_to_errored
 from utils.database import deinitialize_database, initialize_database
@@ -44,6 +46,7 @@ async def lifespan(app: FastAPI):
         region=config.AWS_REGION,
         access_key_id=config.AWS_ACCESS_KEY_ID,
         secret_access_key=config.AWS_SECRET_ACCESS_KEY,
+        _endpoint_url=config.S3_ENDPOINT_URL,
     )
 
     # Loops

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: ridges-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: 
+      POSTGRES_PASSWORD: 
+      POSTGRES_DB: 
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      # TODO Remove this once the alembic logic is merged
+      - ./api/src/backend/postgres_schema.sql:/docker-entrypoint-initdb.d/00_schema.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ridges -d ridges"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  s3mock:
+    image: adobe/s3mock:latest
+    environment:
+      - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=ridges-local
+    ports:
+      - "9090:9090"
+      - "9191:9191"
+
+volumes:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  postgres:
+  db:
     image: postgres:16-alpine
     container_name: ridges-postgres
     ports:
@@ -18,6 +18,20 @@ services:
       timeout: 5s
       retries: 5
     restart: unless-stopped
+
+  api:
+    build:
+      context: .
+      dockerfile: ./api/Dockerfile
+    ports:
+      - "8000:8000"
+    env_file:
+      - ./api/.env
+    depends_on:
+      db:
+        condition: service_healthy
+      s3mock:
+        condition: service_started
 
   s3mock:
     image: adobe/s3mock:latest

--- a/utils/s3.py
+++ b/utils/s3.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import aioboto3
 from botocore.config import Config
 
@@ -6,14 +8,39 @@ import utils.logger as logger
 S3_CLIENT_CONFIG = Config(signature_version="s3v4")
 
 
-async def initialize_s3(*, _bucket: str, region: str, access_key_id: str, secret_access_key: str):
+async def initialize_s3(
+    *,
+    _endpoint_url: Optional[str] = None,
+    _bucket: str,
+    region: str,
+    access_key_id: str,
+    secret_access_key: str,
+):
+    """Initialize the S3 session.
+
+    Parameters
+    ----------
+    _bucket : str
+        Name of the S3 bucket to use for storage.
+    region : str
+        AWS region where the S3 bucket is located.
+    access_key_id : str
+        AWS access key ID for authentication.
+    secret_access_key : str
+        AWS secret access key for authentication.
+    endpoint_url : Optional[str], optional
+        The endpoint URL for the S3 service, by default None. This can be used to connect to S3-compatible services or for testing with local S3 emulators.
+    """
     logger.info(f"Initializing S3 client for bucket {_bucket} in region {region}...")
 
-    global session, bucket
+    global session, bucket, endpoint_url
     session = aioboto3.Session(
-        aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key, region_name=region
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
+        region_name=region,
     )
     bucket = _bucket
+    endpoint_url = _endpoint_url
 
     logger.info(f"S3 client initialized for bucket {_bucket}.")
 
@@ -21,26 +48,37 @@ async def initialize_s3(*, _bucket: str, region: str, access_key_id: str, secret
 async def deinitialize_s3():
     logger.info("Deinitializing S3 client...")
 
-    global session, bucket
+    global session, bucket, endpoint_url
     session = None
     bucket = None
+    endpoint_url = None
 
     logger.info("S3 client deinitialized.")
 
 
-async def upload_text_file_to_s3(path: str, text: str):
-    global session, bucket
+def _s3_client():
+    """Generate an S3 client using the previously created session."""
 
-    async with session.client("s3", config=S3_CLIENT_CONFIG) as s3_client:
+    client_kwargs = {
+        "service_name": "s3",
+        "config": S3_CLIENT_CONFIG,
+    }
+    if endpoint_url:
+        client_kwargs["endpoint_url"] = endpoint_url
+    return session.client(
+        **client_kwargs,
+    )
+
+
+async def upload_text_file_to_s3(path: str, text: str):
+    async with _s3_client() as s3_client:
         logger.info(f"Uploading text file to s3://{bucket}/{path}")
         await s3_client.put_object(Bucket=bucket, Key=path, Body=text.encode("utf-8"))
         logger.info(f"Successfully uploaded text file to s3://{bucket}/{path}")
 
 
 async def download_text_file_from_s3(path: str) -> str:
-    global session, bucket
-
-    async with session.client("s3", config=S3_CLIENT_CONFIG) as s3_client:
+    async with _s3_client() as s3_client:
         logger.info(f"Downloading text file from s3://{bucket}/{path}")
         response = await s3_client.get_object(Bucket=bucket, Key=path)
         body = await response["Body"].read()
@@ -50,9 +88,7 @@ async def download_text_file_from_s3(path: str) -> str:
 
 
 async def generate_presigned_url(key: str, *, ttl_seconds: int = 300) -> str:
-    global session, bucket
-
-    async with session.client("s3", config=S3_CLIENT_CONFIG) as s3_client:
+    async with _s3_client() as s3_client:
         url = await s3_client.generate_presigned_url(
             "get_object",
             Params={"Bucket": bucket, "Key": key},
@@ -63,9 +99,7 @@ async def generate_presigned_url(key: str, *, ttl_seconds: int = 300) -> str:
 
 
 async def generate_presigned_upload_url(key: str, *, ttl_seconds: int = 7200) -> str:
-    global session, bucket
-
-    async with session.client("s3", config=S3_CLIENT_CONFIG) as s3_client:
+    async with _s3_client() as s3_client:
         url = await s3_client.generate_presigned_url(
             "put_object",
             Params={"Bucket": bucket, "Key": key},


### PR DESCRIPTION
## Changelog

This PR introduces a couple of changes to improve the local development setup:

- Add a new optional config `S3_endpoint_url` that allows the user to specify a different S3 URL from the standard AWS one. This is especially useful when using S3 mocks locally
- Small refactor on the `utils/s3.py` logic to aggregate the s3 client initialization logic into a single method
- Add a `docker-compose.yaml` file that allows the developer to run the Postgres DB, Adobe S3 mock and the api service with a single command. This should only be used for development purposes
- Improve root project documentation on how to run the services locally