### PR TITLE
Feature: Update Engine to cap the agent execution time

### DIFF
--- a/execution/engine.py
+++ b/execution/engine.py
@@ -74,10 +74,12 @@ class ExecutionEngine:
         *,
         harbor_results_dir: str | Path | None = None,
         harbor_debug: bool = False,
+        max_agent_timeout_sec: float | None = None,
     ):
         self.inference_url = inference_url
         self.results_dir = harbor_results_dir
         self.debug = harbor_debug
+        self.max_agent_timeout_sec = max_agent_timeout_sec
 
     async def evaluate(
         self,
@@ -194,11 +196,23 @@ class ExecutionEngine:
         job_name = _format_job_name(problem_name=problem_name, evaluation_run_id=evaluation_run_id)
         results_dir = Path(self.results_dir or DEFAULT_RESULTS_DIR).expanduser().resolve()
 
+        # If the Engine specifies a max agent timeout, compare it with the task
+        # spec timeout (if any) and use the lower of the two to avoid accidentally running tasks for too long.
+        spec_timeout = parsed_spec.agent_timeout_sec
+        if self.max_agent_timeout_sec is not None:
+            agent_timeout_sec = (
+                min(spec_timeout, self.max_agent_timeout_sec)
+                if spec_timeout is not None
+                else self.max_agent_timeout_sec
+            )
+        else:
+            agent_timeout_sec = spec_timeout
+
         return ExecutionRunRequest(
             task_dir=task_dir,
             task_name=parsed_spec.task_name,
             task_digest=parsed_spec.task_digest,
-            agent_timeout_sec=parsed_spec.agent_timeout_sec,
+            agent_timeout_sec=agent_timeout_sec,
             results_dir=results_dir,
             job_name=job_name,
         )

--- a/validator/main.py
+++ b/validator/main.py
@@ -505,6 +505,7 @@ async def main():
         inference_url=config.RIDGES_INFERENCE_GATEWAY_URL,
         harbor_results_dir=config.RIDGES_HARBOR_RESULTS_DIR,
         harbor_debug=config.RIDGES_HARBOR_DEBUG,
+        max_agent_timeout_sec=running_agent_timeout_seconds,
     )
 
     # Start the send heartbeat loop


### PR DESCRIPTION
## Changelog

This PR forwards the existing `running_agent_timeout_seconds` variable, defined by the validators, to the `ExecutionEngine`.

This way, if a task definition does not specify a `agent_timeout_sec` the `ExecutionEngine` will fallback to the value defined by the validator. This also allows us to set harder limits at the validator, e.g. task definition has an agent timeout of 30 minutes, but the validator defines a timeout of 15 minutes -> the `ExecutionEngine`  will always pick the lowest value.

This behaviour can be configured by editing the environment variable `VALIDATOR_RUNNING_AGENT_TIMEOUT_SECONDS` on the validator.

