### PR TITLE
Fix: Migration conflict

### DIFF
--- a/alembic/versions/2026_05_07_block_extrinsic_index_to_refunds.py
+++ b/alembic/versions/2026_05_07_block_extrinsic_index_to_refunds.py
@@ -1,7 +1,7 @@
 """block_extrinsic_index_to_refunds
 
 Revision ID: c880b27e2afe
-Revises: 234ed0606f2a
+Revises: e1bb1c104ea1
 Create Date: 2026-05-07 11:03:36.448663
 
 """
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "c880b27e2afe"
-down_revision: Union[str, Sequence[str], None] = "234ed0606f2a"
+down_revision: Union[str, Sequence[str], None] = "e1bb1c104ea1"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Changelog

This PR updates the `2026_05_07_block_extrinsic_index_to_refunds.py` migration to point the correct down revision.