### PR TITLE
Feat: Add status to connected validators

### DIFF
--- a/api/endpoints/validator.py
+++ b/api/endpoints/validator.py
@@ -14,7 +14,6 @@ from pydantic import BaseModel
 import api.config as config
 import utils.logger as logger
 from api.endpoints.validator_models import (
-    ConnectedValidatorInfo,
     ScreenerRegistrationRequest,
     ScreenerRegistrationResponse,
     ValidatorDisconnectRequest,
@@ -39,6 +38,7 @@ from models.evaluation import Evaluation, EvaluationStatus
 from models.evaluation_run import EvaluationRunLogType, EvaluationRunStatus
 from models.harbor_task import read_execution_spec_metadata
 from models.openrouter import OpenRouterRuntimeConfig
+from models.validator import ConnectedValidatorInfo, ValidatorStatus
 from queries.agent import (
     get_agent_by_id,
     get_next_agent_id_awaiting_evaluation_for_validator_hotkey,
@@ -832,14 +832,33 @@ async def validator_finish_evaluation(
 # /validator/connected-validators-info
 @router.get("/connected-validators-info")
 async def validator_connected_validators_info() -> List[ConnectedValidatorInfo]:
+    """Retrieve information about the Validators connected to the platform."""
+    # 1. Retrieve the Internal Flags
+    flags = await get_internal_flags_parsed(
+        [InternalFlagName.VALIDATORS_PAUSED, InternalFlagName.BLACKLISTED_VALIDATORS]
+    )
+    all_paused: bool = flags[InternalFlagName.VALIDATORS_PAUSED]
+    blacklisted: list[str] = flags[InternalFlagName.BLACKLISTED_VALIDATORS]
+
     connected_validators: List[ConnectedValidatorInfo] = []
 
     _validators = list(SESSION_ID_TO_VALIDATOR.values())
+    # 2. Build the Validator objects
     for validator in _validators:
+        if all_paused or validator.hotkey in blacklisted:
+            status = ValidatorStatus.paused
+        elif validator.current_agent is not None:
+            status = (
+                ValidatorStatus.screening if validator.hotkey.startswith("screener-") else ValidatorStatus.evaluating
+            )
+        else:
+            status = ValidatorStatus.available
+
         connected_validator = ConnectedValidatorInfo(
             name=validator.name,
             hotkey=validator.hotkey,
             time_connected=validator.time_connected,
+            status=status,
             time_last_heartbeat=validator.time_last_heartbeat,
             system_metrics=validator.system_metrics,
         )

--- a/api/endpoints/validator_models.py
+++ b/api/endpoints/validator_models.py
@@ -1,11 +1,8 @@
-from datetime import datetime
 from typing import Any, List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-from models.agent import Agent
-from models.evaluation import Evaluation
 from models.evaluation_run import EvaluationRunStatus
 from models.openrouter import OpenRouterRuntimeConfig
 from models.problem import ProblemTestResult
@@ -108,15 +105,3 @@ class ValidatorFinishEvaluationRequest(BaseModel):
 
 class ValidatorFinishEvaluationResponse(BaseModel):
     pass
-
-
-class ConnectedValidatorInfo(BaseModel):
-    name: str
-    hotkey: str
-    time_connected: datetime
-
-    time_last_heartbeat: Optional[datetime] = None
-    system_metrics: Optional[SystemMetrics] = None
-
-    evaluation: Optional[Evaluation] = None
-    agent: Optional[Agent] = None

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,3 @@
+# Models
+
+This module stores all Data Transfer objects used across the project.

--- a/models/validator.py
+++ b/models/validator.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel
+
+from models.agent import Agent
+from models.evaluation import Evaluation
+from utils.system_metrics import SystemMetrics
+
+
+class ValidatorStatus(str, Enum):
+    available = "Available"
+    screening = "Screening"
+    evaluating = "Evaluating"
+    paused = "Paused"
+
+
+class ConnectedValidatorInfo(BaseModel):
+    """Connected Validator Info used as the response
+    schema for the /connected-validators-info endpoint
+    """
+
+    name: str
+    hotkey: str
+    time_connected: datetime
+    status: ValidatorStatus
+
+    time_last_heartbeat: Optional[datetime] = None
+    system_metrics: Optional[SystemMetrics] = None
+
+    evaluation: Optional[Evaluation] = None
+    agent: Optional[Agent] = None


### PR DESCRIPTION
## Changelog

This PR add the `status` field to the `/connected-validators-info` endpoint. It calculates the Validator's status based on the Internal Flags (i.e. If the global pause is set to True or the Validator is blacklisted, the status will be set to "Paused") and if it has a running agent or not.

The endpoint response schema was moved to the `/models` module to comply with the latest project standards.