### PR TITLE
Feat/add payment quotes

### DIFF
--- a/alembic/versions/2026_06_10_upload_payment_quotes.py
+++ b/alembic/versions/2026_06_10_upload_payment_quotes.py
@@ -1,7 +1,7 @@
 """Add upload payment quotes
 
-Revision ID: f0a1b2c3d4e5
-Revises: c4d9a2e7f813
+Revision ID: 353d6b475738
+Revises: d4cb2c9dc03c
 Create Date: 2026-06-10 00:00:00.000000
 
 """
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision: str = "f0a1b2c3d4e5"
-down_revision: Union[str, Sequence[str], None] = "c4d9a2e7f813"
+revision: str = "353d6b475738"
+down_revision: Union[str, Sequence[str], None] = "d4cb2c9dc03c"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/2026_06_10_upload_payment_quotes.py
+++ b/alembic/versions/2026_06_10_upload_payment_quotes.py
@@ -1,0 +1,54 @@
+"""Add upload payment quotes
+
+Revision ID: f0a1b2c3d4e5
+Revises: c4d9a2e7f813
+Create Date: 2026-06-10 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "f0a1b2c3d4e5"
+down_revision: Union[str, Sequence[str], None] = "c4d9a2e7f813"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "upload_payment_quotes",
+        sa.Column("quote_id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("miner_hotkey", sa.Text(), nullable=False),
+        sa.Column("amount_rao", sa.BigInteger(), nullable=False),
+        sa.Column("send_address", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.text("NOW()"), nullable=False),
+        sa.Column("expires_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("quote_id"),
+    )
+    op.create_index(
+        "idx_upload_payment_quotes_miner_hotkey_created_at",
+        "upload_payment_quotes",
+        ["miner_hotkey", "created_at"],
+    )
+
+    op.add_column("evaluation_payments", sa.Column("quote_id", sa.UUID(), nullable=True))
+    op.create_foreign_key(
+        "fk_evaluation_payments_quote_id",
+        "evaluation_payments",
+        "upload_payment_quotes",
+        ["quote_id"],
+        ["quote_id"],
+    )
+    op.create_unique_constraint("uq_evaluation_payments_quote_id", "evaluation_payments", ["quote_id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_evaluation_payments_quote_id", "evaluation_payments", type_="unique")
+    op.drop_constraint("fk_evaluation_payments_quote_id", "evaluation_payments", type_="foreignkey")
+    op.drop_column("evaluation_payments", "quote_id")
+    op.drop_index("idx_upload_payment_quotes_miner_hotkey_created_at", table_name="upload_payment_quotes")
+    op.drop_table("upload_payment_quotes")

--- a/api/src/endpoints/upload.py
+++ b/api/src/endpoints/upload.py
@@ -6,13 +6,13 @@ from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
-from pydantic import BaseModel, Field
 
 from api import config
 from api.errors import PaymentAlreadyUsedError, PaymentRefunded, PlatformFrozenError
 from api.src.utils.openrouter_validation import validate_openrouter_keys
 from api.src.utils.request_cache import hourly_cache
 from api.src.utils.upload_agent_helpers import (
+    as_utc,
     check_agent_banned,
     check_file_size,
     check_hotkey_registered,
@@ -21,8 +21,10 @@ from api.src.utils.upload_agent_helpers import (
     check_signature,
     get_miner_hotkey,
     get_tao_price,
+    timestamp_ms_to_utc_datetime,
 )
 from models.agent import Agent, AgentCreate, AgentStatus
+from models.upload import AgentCheckResponse, AgentUploadResponse, ErrorResponse, UploadPriceResponse
 from queries.agent import (
     create_agent,
     get_latest_agent_created_at_for_miner_hotkey_in_latest_set_id,
@@ -58,50 +60,6 @@ async def get_hotkey_lock(hotkey: str) -> asyncio.Lock:
         if hotkey not in hotkey_locks:
             hotkey_locks[hotkey] = asyncio.Lock()
         return hotkey_locks[hotkey]
-
-
-class AgentUploadResponse(BaseModel):
-    """Response model for successful agent upload"""
-
-    status: str = Field(..., description="Status of the upload operation")
-    message: str = Field(..., description="Detailed message about the upload result")
-
-
-class UploadPriceResponse(BaseModel):
-    """Response model for upload pricing"""
-
-    amount_rao: int = Field(..., description="Amount to send for evaluation (in RAO)")
-    send_address: str = Field(..., description="TAO address to send evaluation payment to")
-
-
-class AgentCheckResponse(AgentUploadResponse):
-    """Response model for successful agent upload preflight checks"""
-
-    quote_id: UUID = Field(..., description="Quote ID to include when uploading or resuming")
-    amount_rao: int = Field(..., description="Amount to send for evaluation (in RAO)")
-    send_address: str = Field(..., description="TAO address to send evaluation payment to")
-    expires_at: datetime = Field(..., description="Latest on-chain payment timestamp accepted for this quote")
-
-
-class ErrorResponse(BaseModel):
-    """Error response model"""
-
-    detail: str = Field(..., description="Error message describing what went wrong")
-
-
-def _timestamp_ms_to_utc_datetime(timestamp_ms: int | None) -> datetime:
-    if timestamp_ms is None:
-        raise HTTPException(status_code=402, detail="Payment block timestamp not found")
-    try:
-        return datetime.fromtimestamp(int(timestamp_ms) / 1000, timezone.utc)
-    except (TypeError, ValueError):
-        raise HTTPException(status_code=402, detail="Payment block timestamp could not be decoded") from None
-
-
-def _as_utc(dt: datetime) -> datetime:
-    if dt.tzinfo is None:
-        return dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc)
 
 
 router = APIRouter()
@@ -323,8 +281,8 @@ async def post_agent(
             if payment_value != quote.amount_rao:
                 raise HTTPException(status_code=402, detail="Payment amount does not match")
 
-            payment_block_time = _timestamp_ms_to_utc_datetime(payment_block_info.timestamp)
-            if not (_as_utc(quote.created_at) <= payment_block_time <= _as_utc(quote.expires_at)):
+            payment_block_time = timestamp_ms_to_utc_datetime(payment_block_info.timestamp)
+            if not (as_utc(quote.created_at) <= payment_block_time <= as_utc(quote.expires_at)):
                 raise HTTPException(status_code=402, detail="Payment was made outside the quote validity window")
 
         validated_openrouter_keys = await validate_openrouter_keys(

--- a/api/src/endpoints/upload.py
+++ b/api/src/endpoints/upload.py
@@ -1,8 +1,9 @@
 import asyncio
 import hashlib
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
+from uuid import UUID
 
 from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
 from pydantic import BaseModel, Field
@@ -32,8 +33,10 @@ from queries.banned_hotkey import get_banned_hotkey
 from queries.errors import DuplicateAgentIDError
 from queries.payments import (
     complete_payment,
+    create_payment_quote,
     reserve_payment,
     retrieve_payment_by_hash,
+    retrieve_payment_quote,
 )
 from queries.refund import is_payment_refunded
 from utils.agent_secrets import encrypt_agent_secret
@@ -41,6 +44,9 @@ from utils.bittensor import subtensor_client
 from utils.debug_lock import DebugLock
 
 logger = logging.getLogger(__name__)
+
+UPLOAD_PAYMENT_QUOTE_TTL_SECONDS = 60 * 60
+OUTDATED_UPLOAD_CLIENT_MESSAGE = "This upload client is outdated. Please upgrade Ridges CLI and retry."
 
 # We use a lock per hotkey to prevent multiple agents being uploaded at the same time for the same hotkey
 hotkey_locks: dict[str, asyncio.Lock] = {}
@@ -61,16 +67,47 @@ class AgentUploadResponse(BaseModel):
     message: str = Field(..., description="Detailed message about the upload result")
 
 
+class UploadPriceResponse(BaseModel):
+    """Response model for upload pricing"""
+
+    amount_rao: int = Field(..., description="Amount to send for evaluation (in RAO)")
+    send_address: str = Field(..., description="TAO address to send evaluation payment to")
+
+
+class AgentCheckResponse(AgentUploadResponse):
+    """Response model for successful agent upload preflight checks"""
+
+    quote_id: UUID = Field(..., description="Quote ID to include when uploading or resuming")
+    amount_rao: int = Field(..., description="Amount to send for evaluation (in RAO)")
+    send_address: str = Field(..., description="TAO address to send evaluation payment to")
+    expires_at: datetime = Field(..., description="Latest on-chain payment timestamp accepted for this quote")
+
+
 class ErrorResponse(BaseModel):
     """Error response model"""
 
     detail: str = Field(..., description="Error message describing what went wrong")
 
 
+def _timestamp_ms_to_utc_datetime(timestamp_ms: int | None) -> datetime:
+    if timestamp_ms is None:
+        raise HTTPException(status_code=402, detail="Payment block timestamp not found")
+    try:
+        return datetime.fromtimestamp(int(timestamp_ms) / 1000, timezone.utc)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=402, detail="Payment block timestamp could not be decoded") from None
+
+
+def _as_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
 router = APIRouter()
 
 
-@router.post("/agent/check", tags=["upload"], response_model=AgentUploadResponse)
+@router.post("/agent/check", tags=["upload"], response_model=AgentCheckResponse)
 async def check_agent_post(
     request: Request,
     agent_file: UploadFile = File(..., description="Python file containing the agent code (must be named agent.py)"),
@@ -80,12 +117,11 @@ async def check_agent_post(
     ),
     signature: str = Form(..., description="Signature to verify the authenticity of the upload"),
     name: str = Form(..., description="Name of the agent"),
-    payment_time: float = Form(..., description="Timestamp of the payment"),
     openrouter_api_key: str = Form(..., description="OpenRouter API key for inference during evaluation"),
     openrouter_management_key: str = Form(
         ..., description="OpenRouter management key used to validate workspace privacy settings"
     ),
-) -> AgentUploadResponse:
+) -> AgentCheckResponse:
     if config.DISALLOW_UPLOADS:
         raise HTTPException(status_code=503, detail=config.DISALLOW_UPLOADS_REASON)
     miner_hotkey = get_miner_hotkey(file_info)
@@ -101,7 +137,7 @@ async def check_agent_post(
     await check_file_size(agent_file)
     coldkey = await subtensor_client.get_hotkey_owner(miner_hotkey)
     miner_balance = (await subtensor_client.get_balance(coldkey)).rao
-    payment_cost = await get_upload_price(cache_time=payment_time)
+    payment_cost = await get_upload_price()
     if payment_cost.amount_rao > miner_balance:
         raise HTTPException(
             status_code=402,
@@ -111,7 +147,21 @@ async def check_agent_post(
         openrouter_api_key=openrouter_api_key,
         openrouter_management_key=openrouter_management_key,
     )
-    return AgentUploadResponse(status="success", message="Agent check successful")
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=UPLOAD_PAYMENT_QUOTE_TTL_SECONDS)
+    quote = await create_payment_quote(
+        miner_hotkey=miner_hotkey,
+        amount_rao=payment_cost.amount_rao,
+        send_address=payment_cost.send_address,
+        expires_at=expires_at,
+    )
+    return AgentCheckResponse(
+        status="success",
+        message="Agent check successful",
+        quote_id=quote.quote_id,
+        amount_rao=quote.amount_rao,
+        send_address=quote.send_address,
+        expires_at=quote.expires_at,
+    )
 
 
 @router.post(
@@ -138,7 +188,7 @@ async def post_agent(
     name: str = Form(..., description="Name of the agent"),
     payment_block_hash: str = Form(..., description="Block hash in which payment was made"),
     payment_extrinsic_index: str = Form(..., description="Index in the block for payment extrinsic"),
-    payment_time: float = Form(..., description="Timestamp of the payment"),
+    quote_id: Optional[str] = Form(None, description="Server-issued upload payment quote ID"),
     openrouter_api_key: str = Form(..., description="OpenRouter API key for inference during evaluation"),
     openrouter_management_key: str = Form(
         ..., description="OpenRouter management key used to validate workspace privacy settings"
@@ -194,13 +244,28 @@ async def post_agent(
         source_sha256 = hashlib.sha256(agent_bytes).hexdigest()
 
         if prod and not is_owner_upload:
-            # Verify payment
-            # Check if payment has already been used for an agent
+            if quote_id is None:
+                raise HTTPException(status_code=400, detail=OUTDATED_UPLOAD_CLIENT_MESSAGE)
+
+            try:
+                quote_uuid = UUID(quote_id)
+            except ValueError:
+                raise HTTPException(status_code=400, detail="Invalid payment quote ID") from None
+
+            quote = await retrieve_payment_quote(quote_uuid)
+            if quote is None:
+                raise HTTPException(status_code=400, detail="Invalid payment quote ID")
+
+            if quote.miner_hotkey != miner_hotkey:
+                raise HTTPException(status_code=402, detail="Payment quote does not match upload hotkey")
+
             existing_payment = await retrieve_payment_by_hash(
                 payment_block_hash=payment_block_hash, payment_extrinsic_index=payment_extrinsic_index
             )
             if existing_payment is not None and existing_payment.agent_id is not None:
                 raise DuplicateAgentIDError(agent_id=existing_payment.agent_id)
+            if existing_payment is not None and existing_payment.quote_id != quote.quote_id:
+                raise HTTPException(status_code=409, detail="Payment is already reserved for a different quote")
 
             if await is_payment_refunded(
                 upload_block_hash=payment_block_hash, upload_extrinsic_index=payment_extrinsic_index
@@ -210,68 +275,53 @@ async def post_agent(
 
             # Retrieve payment details from the chain
             try:
-                payment_block = await subtensor_client.get_block(block_hash=payment_block_hash)
+                payment_block_info = await subtensor_client.get_block_info(block_hash=payment_block_hash)
             except Exception as e:
                 logger.error(f"Error retrieving payment block: {e}")
                 raise HTTPException(status_code=402, detail="Payment could not be verified")
 
-            if payment_block is None:
+            if payment_block_info is None:
                 raise HTTPException(status_code=402, detail="Payment block not found")
 
-            # example payment block:
-            """
-            {'extrinsics': [<GenericExtrinsic(value={'extrinsic_hash': '0x6b6f2be8e0d0e7721fab46da881d894dafa221b4df73ebb2b69a8c0aa5aeb01b', 'extrinsic_length': 10, 'call': {'call_index': '0x0200', 'call_function': 'set', 'call_module': 'Timestamp', 'call_args': [{'name': 'now', 'type': 'Moment', 'value': 1763573265504}], 'call_hash': '0x5cad44676af19a09d4ae5354e08570778c06b75257a932db8183b90910d0c33e'}})>,
-                    <GenericExtrinsic(value={'extrinsic_hash': '0x350253844e42eda50ed13c043c6124db65189bf00a968467c763d54861492295', 'extrinsic_length': 142, 'address': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm', 'signature': {'Sr25519': '0x2eb063251883f68aa6fad463f32d31c7f8635ec4550e1197ce1a0913b6182a065880ea5af1b68026ad996beedb803685d6d67e56e097a4d7666c7e075da2778f'}, 'era': '00', 'nonce': 14, 'tip': 0, 'mode': {'mode': 'Disabled'}, 'call': {'call_index': '0x0503', 'call_function': 'transfer_keep_alive', 'call_module': 'Balances', 'call_args': [{'name': 'dest', 'type': 'AccountIdLookupOf', 'value': '5F4Thj3LRZdjSAnUhymAVVq2X2czSAKD4uGNCnqW8JrCHWE4'}, {'name': 'value', 'type': 'Balance', 'value': 271449345}], 'call_hash': '0x20f54967ae95d9b4304d5582d8343469894c637d2d1c557c7bb0ad1f27797797'}})>],
-     'header': {'digest': {'logs': [<scale_info::17(value={'PreRuntime': ('0x61757261', '0x46f877a401000000')})>,
-                                    <scale_info::17(value={'Consensus': ('0x66726f6e', '0x012f7e87441378c60d18e9b676246e74ca17064ff510b10dfed2a48191648a1a9400')})>,
-                                    <scale_info::17(value={'Seal': ('0x61757261', '0x44729c195bda22d4e9dce35ed7e43fd1652e7782cb38cf27cc8489fb0460af1f4c97621e5e29c19e730051df736441d3359799c7002eb81350e169bb9fcecb80')})>]},
-                'extrinsicsRoot': '0x980d155f4b5a6f08d287c54e0a32380839cdfc0a5977200e33aa5787b48ec669',
-                'hash': '0xb9958e4374c182785bfa4467ceb971e23882079f48524e27c08e8f5b95d8b8d8',
-                'number': 13579,
-                'parentHash': '0x1065e83a02ff961d45ac34a6990477de3cba102bbba2322950815e5d59f23135',
-                'stateRoot': '0x301a04303fb97143649e44ca9c1d674606c8004082d11973c816ff67f2a13998'}}
-            """
-            block_number = payment_block["header"]["number"]
-            coldkey = await subtensor_client.get_hotkey_owner(miner_hotkey, block=int(block_number))
-            payment_extrinsic = payment_block["extrinsics"][int(payment_extrinsic_index)]
+            coldkey = await subtensor_client.get_hotkey_owner(miner_hotkey, block=int(payment_block_info.number))
+            payment_extrinsic_index_int = int(payment_extrinsic_index)
+            payment_extrinsic = payment_block_info.extrinsics[payment_extrinsic_index_int]
+            payment_extrinsic_value = payment_extrinsic.value_serialized
+            payment_call = payment_extrinsic_value["call"]
 
-            # Example payment extrinsic:
-            """
-            <GenericExtrinsic(value={'extrinsic_hash': '0x350253844e42eda50ed13c043c6124db65189bf00a968467c763d54861492295', 'extrinsic_length': 142, 'address': '5DhaT8U7LVwnnJNUU8VL1XEipicatoaDVVq7cHo227gogVZm', 'signature': {'Sr25519': '0x2eb063251883f68aa6fad463f32d31c7f8635ec4550e1197ce1a0913b6182a065880ea5af1b68026ad996beedb803685d6d67e56e097a4d7666c7e075da2778f'}, 'era': '00', 'nonce': 14, 'tip': 0, 'mode': {'mode': 'Disabled'}, 'call': {'call_index': '0x0503', 'call_function': 'transfer_keep_alive', 'call_module': 'Balances', 'call_args': [{'name': 'dest', 'type': 'AccountIdLookupOf', 'value': '5F4Thj3LRZdjSAnUhymAVVq2X2czSAKD4uGNCnqW8JrCHWE4'}, {'name': 'value', 'type': 'Balance', 'value': 271449345}], 'call_hash': '0x20f54967ae95d9b4304d5582d8343469894c637d2d1c557c7bb0ad1f27797797'}})>
-            """
-            payment_value = None
-            for arg in payment_extrinsic.value["call"]["call_args"]:
-                if arg["name"] == "value":
-                    payment_value = arg["value"]
-                    break
+            if (
+                payment_call.get("call_module") != "Balances"
+                or payment_call.get("call_function") != "transfer_keep_alive"
+            ):
+                raise HTTPException(status_code=402, detail="Payment extrinsic is not a TAO transfer")
+
+            call_args = {arg["name"]: arg["value"] for arg in payment_call["call_args"]}
+            payment_value = call_args.get("value")
+            destination = call_args.get("dest")
+            payment_address = payment_extrinsic_value["address"]
 
             if payment_value is None or await check_if_extrinsic_failed(
-                payment_block_hash, int(payment_extrinsic_index)
+                payment_block_hash, payment_extrinsic_index_int
             ):
                 raise HTTPException(status_code=402, detail="Payment value not found")
 
-            # Only validate the paid amount against the spot price for a payment we haven't seen before.
-            # If it was already reserved (existing_payment with no agent_id), it passed this check when first reserved.
-            if existing_payment is None:
-                payment_cost = await get_upload_price(cache_time=payment_time)
-                if payment_value != payment_cost.amount_rao:
-                    raise HTTPException(status_code=402, detail="Payment amount does not match")
-
             # Make sure coldkey is the same as hotkeys owner coldkey
-            if coldkey != payment_extrinsic["address"]:
+            if coldkey != payment_address:
                 raise HTTPException(status_code=402, detail="Coldkey does not match")
 
             # Make sure destination is our upload send address
-            destination = None
-            for arg in payment_extrinsic.value["call"]["call_args"]:
-                if arg["name"] == "dest":
-                    destination = arg["value"]
-                    break
-            if destination != config.UPLOAD_SEND_ADDRESS:
+            if destination != quote.send_address:
                 raise HTTPException(
                     status_code=402,
-                    detail=f"Destination does not match. The payment should be sent to {config.UPLOAD_SEND_ADDRESS}",
+                    detail=f"Destination does not match. The payment should be sent to {quote.send_address}",
                 )
+
+            if payment_value != quote.amount_rao:
+                raise HTTPException(status_code=402, detail="Payment amount does not match")
+
+            payment_block_time = _timestamp_ms_to_utc_datetime(payment_block_info.timestamp)
+            if not (_as_utc(quote.created_at) <= payment_block_time <= _as_utc(quote.expires_at)):
+                raise HTTPException(status_code=402, detail="Payment was made outside the quote validity window")
 
         validated_openrouter_keys = await validate_openrouter_keys(
             openrouter_api_key=openrouter_api_key,
@@ -296,10 +346,17 @@ async def post_agent(
                     miner_hotkey=miner_hotkey,
                     miner_coldkey=coldkey,
                     amount_rao=payment_value,
+                    quote_id=quote.quote_id,
                 )
+
+                if payment_row is None:
+                    raise HTTPException(status_code=409, detail="Payment or quote is already reserved")
 
                 if payment_row.agent_id is not None:
                     raise DuplicateAgentIDError(agent_id=payment_row.agent_id)
+
+                if payment_row.quote_id != quote.quote_id:
+                    raise HTTPException(status_code=409, detail="Payment is already reserved for a different quote")
 
             encrypted_openrouter_api_key = encrypt_agent_secret(validated_openrouter_keys.runtime_api_key)
             encrypted_openrouter_management_key = encrypt_agent_secret(validated_openrouter_keys.management_api_key)
@@ -387,13 +444,6 @@ async def post_agent(
             **upload_data,
         )
         raise
-
-
-class UploadPriceResponse(BaseModel):
-    """Response model for successful agent upload"""
-
-    amount_rao: int = Field(..., description="Amount to send for evaluation (in RAO)")
-    send_address: str = Field(..., description="TAO address to send evaluation payment to")
 
 
 @router.get("/eval-pricing", tags=["eval-pricing"], response_model=UploadPriceResponse)

--- a/api/src/endpoints/upload.py
+++ b/api/src/endpoints/upload.py
@@ -284,21 +284,25 @@ async def post_agent(
                 raise HTTPException(status_code=402, detail="Payment block not found")
 
             coldkey = await subtensor_client.get_hotkey_owner(miner_hotkey, block=int(payment_block_info.number))
-            payment_extrinsic_index_int = int(payment_extrinsic_index)
-            payment_extrinsic = payment_block_info.extrinsics[payment_extrinsic_index_int]
-            payment_extrinsic_value = payment_extrinsic.value_serialized
-            payment_call = payment_extrinsic_value["call"]
+            try:
+                payment_extrinsic_index_int = int(payment_extrinsic_index)
+                if payment_extrinsic_index_int < 0:
+                    raise ValueError
+                payment_extrinsic = payment_block_info.extrinsics[payment_extrinsic_index_int]
+                payment_extrinsic_value = payment_extrinsic.value_serialized
+                payment_call = payment_extrinsic_value["call"]
+                call_args = {arg["name"]: arg["value"] for arg in payment_call["call_args"]}
+                payment_value = call_args.get("value")
+                destination = call_args.get("dest")
+                payment_address = payment_extrinsic_value["address"]
+            except (ValueError, TypeError, IndexError, KeyError, AttributeError):
+                raise HTTPException(status_code=402, detail="Payment extrinsic could not be decoded") from None
 
             if (
                 payment_call.get("call_module") != "Balances"
                 or payment_call.get("call_function") != "transfer_keep_alive"
             ):
                 raise HTTPException(status_code=402, detail="Payment extrinsic is not a TAO transfer")
-
-            call_args = {arg["name"]: arg["value"] for arg in payment_call["call_args"]}
-            payment_value = call_args.get("value")
-            destination = call_args.get("dest")
-            payment_address = payment_extrinsic_value["address"]
 
             if payment_value is None or await check_if_extrinsic_failed(
                 payment_block_hash, payment_extrinsic_index_int

--- a/api/src/utils/upload_agent_helpers.py
+++ b/api/src/utils/upload_agent_helpers.py
@@ -69,6 +69,21 @@ def check_rate_limit(latest_agent_created_at_in_latest_set_id: datetime) -> None
     logger.debug("Miner is not rate limited.")
 
 
+def timestamp_ms_to_utc_datetime(timestamp_ms: int | None) -> datetime:
+    if timestamp_ms is None:
+        raise HTTPException(status_code=402, detail="Payment block timestamp not found")
+    try:
+        return datetime.fromtimestamp(int(timestamp_ms) / 1000, timezone.utc)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=402, detail="Payment block timestamp could not be decoded") from None
+
+
+def as_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
 def check_signature(public_key: str, file_info: str, signature: str, miner_hotkey: str) -> None:
     logger.debug("Checking if the signature is valid...")
     logger.debug(f"Public key: {public_key}, File info: {file_info}, Signature: {signature}.")

--- a/db/models/__init__.py
+++ b/db/models/__init__.py
@@ -20,7 +20,7 @@ from db.models.internal_flag import (
     InternalFlag,
     InternalFlagName,  # noqa: F401
 )
-from db.models.payment import EvaluationPayment
+from db.models.payment import EvaluationPayment, UploadPaymentQuote
 from db.models.pre_screening_judge import PreScreeningJob, PreScreeningResult
 from db.models.refund import FailedUploadRefund
 from db.models.upload import UploadAttempt
@@ -48,5 +48,6 @@ __all__ = [
     "InternalFlag",
     "UnapprovedAgentId",
     "UploadAttempt",
+    "UploadPaymentQuote",
     "Competition",
 ]

--- a/db/models/payment.py
+++ b/db/models/payment.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
@@ -13,6 +14,12 @@ class EvaluationPayment(Base, CreatedAtMixin):
 
     payment_block_hash: Mapped[str] = mapped_column(sa.Text, nullable=False)
     payment_extrinsic_index: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    quote_id: Mapped[Optional[UUID]] = mapped_column(
+        PG_UUID(as_uuid=True),
+        sa.ForeignKey("upload_payment_quotes.quote_id"),
+        nullable=True,
+        comment="Server-issued upload payment quote used to validate amount, destination, hotkey, and payment time.",
+    )
     agent_id: Mapped[Optional[UUID]] = mapped_column(
         PG_UUID(as_uuid=True),
         sa.ForeignKey("agents.agent_id"),
@@ -24,3 +31,17 @@ class EvaluationPayment(Base, CreatedAtMixin):
     amount_rao: Mapped[int] = mapped_column(sa.Integer, nullable=False)
 
     __table_args__ = (sa.PrimaryKeyConstraint("payment_block_hash", "payment_extrinsic_index"),)
+
+
+class UploadPaymentQuote(Base, CreatedAtMixin):
+    __tablename__ = "upload_payment_quotes"
+
+    quote_id: Mapped[UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+    miner_hotkey: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    amount_rao: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
+    send_address: Mapped[str] = mapped_column(sa.Text, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(sa.TIMESTAMP(timezone=True), nullable=False)

--- a/miners/cli/commands/upload.py
+++ b/miners/cli/commands/upload.py
@@ -512,11 +512,10 @@ def team_upload(
     "--openrouter-management-key",
     help="OpenRouter management key. Falls back to RIDGES_OPENROUTER_MANAGEMENT_KEY or an interactive prompt.",
 )
-@click.option("--quote-id", required=True, help="Payment Quote ID printed after the original payment.")
-@click.option("--payment-block-hash", required=True, help="Payment Block Hash printed after the original payment.")
+@click.option("--quote-id", help="Payment Quote ID printed after the original payment.")
+@click.option("--payment-block-hash", help="Payment Block Hash printed after the original payment.")
 @click.option(
     "--payment-extrinsic-index",
-    required=True,
     type=int,
     help="Payment Extrinsic Index printed after the original payment.",
 )
@@ -528,9 +527,9 @@ def resume_upload(
     hotkey_name: Optional[str],
     openrouter_api_key: Optional[str],
     openrouter_management_key: Optional[str],
-    quote_id: str,
-    payment_block_hash: str,
-    payment_extrinsic_index: int,
+    quote_id: Optional[str],
+    payment_block_hash: Optional[str],
+    payment_extrinsic_index: Optional[int],
 ):
     """Resume a failed upload using an existing payment receipt."""
     wallet, target = _resolve_wallet_and_target(ctx, file=file, coldkey_name=coldkey_name, hotkey_name=hotkey_name)
@@ -539,6 +538,11 @@ def resume_upload(
         openrouter_management_key=openrouter_management_key,
     )
     _print_upload_preview(hotkey=wallet.hotkey.ss58_address, target=target)
+
+    quote_id = quote_id or Prompt.ask("Payment Quote ID")
+    payment_block_hash = payment_block_hash or Prompt.ask("Payment Block Hash")
+    if payment_extrinsic_index is None:
+        payment_extrinsic_index = int(Prompt.ask("Payment Extrinsic Index"))
 
     receipt = PaymentReceipt(
         block_hash=payment_block_hash,

--- a/miners/cli/commands/upload.py
+++ b/miners/cli/commands/upload.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import os
-import time
 import uuid as _uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -48,7 +47,7 @@ class PendingUpload:
 class PaymentReceipt:
     block_hash: str
     extrinsic_index: int
-    payment_time: float
+    quote_id: Optional[str] = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -160,13 +159,12 @@ def _check_upload_allowed(
     target: UploadTarget,
     pending: PendingUpload,
     credentials: OpenRouterUploadCredentials,
-) -> None:
+) -> dict:
     check_payload = {
         "public_key": pending.public_key,
         "file_info": pending.file_info,
         "signature": pending.signature,
         "name": pending.name,
-        "payment_time": time.time(),
         "openrouter_api_key": credentials.runtime_api_key,
         "openrouter_management_key": credentials.management_key,
     }
@@ -178,13 +176,21 @@ def _check_upload_allowed(
     )
     if response.status_code != 200:
         raise click.ClickException(f"Error checking agent: {response.text}")
-
-
-def _fetch_eval_pricing(client: httpx.Client, *, api_url: str) -> dict:
-    response = client.get(f"{api_url}/upload/eval-pricing")
-    if response.status_code != 200:
-        raise click.ClickException("Error fetching evaluation cost")
     return response.json()
+
+
+def _unlock_coldkey(wallet) -> None:
+    """Unlock the coldkey, re-prompting on incorrect password."""
+    from bittensor_wallet.errors import KeyFileError, PasswordError
+
+    while True:
+        try:
+            wallet.unlock_coldkey()
+            return
+        except PasswordError:
+            console.print("[bold red]Failed:[/bold red] The password used to decrypt your Coldkey keyfile is invalid.")
+        except KeyFileError as exc:
+            raise click.ClickException(str(exc)) from exc
 
 
 def _confirm_payment(payment_method_details: dict) -> bool:
@@ -204,7 +210,6 @@ def _submit_eval_payment(*, wallet, payment_method_details: dict) -> PaymentRece
     from bittensor import Subtensor
 
     subtensor = Subtensor(network=os.environ.get("SUBTENSOR_NETWORK", "finney"))
-    payment_time = time.time()
     payment_payload = subtensor.substrate.compose_call(
         call_module="Balances",
         call_function="transfer_keep_alive",
@@ -222,7 +227,7 @@ def _submit_eval_payment(*, wallet, payment_method_details: dict) -> PaymentRece
     return PaymentReceipt(
         block_hash=receipt.block_hash,
         extrinsic_index=receipt.extrinsic_idx,
-        payment_time=payment_time,
+        quote_id=payment_method_details["quote_id"],
     )
 
 
@@ -231,6 +236,8 @@ def _print_payment_receipt(receipt: PaymentReceipt) -> None:
         "\n[yellow]Payment extrinsic submitted. If something goes wrong with the upload, "
         "you can use this information to get a refund[/yellow]"
     )
+    if receipt.quote_id:
+        console.print(f"[cyan]Payment Quote ID:[/cyan] {receipt.quote_id}")
     console.print(f"[cyan]Payment Block Hash:[/cyan] {receipt.block_hash}")
     console.print(f"[cyan]Payment Extrinsic Index:[/cyan] {receipt.extrinsic_index}\n")
 
@@ -240,23 +247,23 @@ def _upload_payload(
     pending: PendingUpload,
     receipt: PaymentReceipt,
     credentials: OpenRouterUploadCredentials,
-) -> dict[str, str | int | float]:
-    return {
+) -> dict[str, str | int]:
+    payload: dict[str, str | int] = {
         "public_key": pending.public_key,
         "file_info": pending.file_info,
         "signature": pending.signature,
         "name": pending.name,
         "payment_block_hash": receipt.block_hash,
         "payment_extrinsic_index": receipt.extrinsic_index,
-        "payment_time": receipt.payment_time,
         "openrouter_api_key": credentials.runtime_api_key,
         "openrouter_management_key": credentials.management_key,
     }
+    if receipt.quote_id is not None:
+        payload["quote_id"] = receipt.quote_id
+    return payload
 
 
-def _submit_upload(
-    client: httpx.Client, *, target: UploadTarget, payload: dict[str, str | int | float]
-) -> httpx.Response:
+def _submit_upload(client: httpx.Client, *, target: UploadTarget, payload: dict[str, str | int]) -> httpx.Response:
     files = {"agent_file": ("agent.py", target.file_content, "text/plain")}
     with Progress(
         SpinnerColumn(),
@@ -292,6 +299,18 @@ def _handle_upload_result(response: httpx.Response, *, name: str) -> None:
     raise click.ClickException(f"Upload failed ({response.status_code}): {error}")
 
 
+def _prepare_pending_upload(*, client: httpx.Client, wallet: Wallet, target: UploadTarget) -> PendingUpload:
+    name, version_num = _resolve_upload_name_and_version(
+        client, api_url=target.api_url, hotkey=wallet.hotkey.ss58_address
+    )
+    return _build_pending_upload(
+        wallet=wallet,
+        name=name,
+        version_num=version_num,
+        content_hash=target.content_hash,
+    )
+
+
 def _execute_upload(
     client: httpx.Client,
     *,
@@ -299,6 +318,7 @@ def _execute_upload(
     target: UploadTarget,
     credentials: OpenRouterUploadCredentials,
     receipt: PaymentReceipt,
+    pending: Optional[PendingUpload] = None,
     run_check: bool = True,
 ) -> None:
     """Shared post-payment upload steps used by both upload and resume-upload.
@@ -318,20 +338,13 @@ def _execute_upload(
     run_check : bool, optional
         If True validate if upload is allowed, by default True
     """
-    name, version_num = _resolve_upload_name_and_version(
-        client, api_url=target.api_url, hotkey=wallet.hotkey.ss58_address
-    )
-    pending = _build_pending_upload(
-        wallet=wallet,
-        name=name,
-        version_num=version_num,
-        content_hash=target.content_hash,
-    )
+    if pending is None:
+        pending = _prepare_pending_upload(client=client, wallet=wallet, target=target)
     if run_check:
         _check_upload_allowed(client, target=target, pending=pending, credentials=credentials)
     payload = _upload_payload(pending=pending, receipt=receipt, credentials=credentials)
     response = _submit_upload(client, target=target, payload=payload)
-    _handle_upload_result(response, name=name)
+    _handle_upload_result(response, name=pending.name)
 
 
 def _resolve_wallet_and_target(
@@ -392,7 +405,11 @@ def upload(
 
     try:
         with httpx.Client() as client:
-            payment_method_details = _fetch_eval_pricing(client, api_url=target.api_url)
+            pending = _prepare_pending_upload(client=client, wallet=wallet, target=target)
+            payment_method_details = _check_upload_allowed(
+                client, target=target, pending=pending, credentials=credentials
+            )
+            _unlock_coldkey(wallet)
             if not _confirm_payment(payment_method_details):
                 console.print("[bold red]Payment cancelled by user. Upload aborted.[/bold red]")
                 return
@@ -400,7 +417,15 @@ def upload(
             receipt = _submit_eval_payment(wallet=wallet, payment_method_details=payment_method_details)
             _print_payment_receipt(receipt)
 
-            _execute_upload(client, wallet=wallet, target=target, credentials=credentials, receipt=receipt)
+            _execute_upload(
+                client,
+                wallet=wallet,
+                target=target,
+                credentials=credentials,
+                receipt=receipt,
+                pending=pending,
+                run_check=False,
+            )
 
     except click.ClickException:
         raise
@@ -452,7 +477,6 @@ def team_upload(
     receipt = PaymentReceipt(
         block_hash=_uuid.uuid4().hex,
         extrinsic_index=0,
-        payment_time=time.time(),
     )
 
     try:
@@ -473,8 +497,8 @@ def team_upload(
     short_help="Resume a failed upload using an existing payment receipt.",
     help=format_help(
         "Resume an upload that failed after payment was already submitted on-chain. "
-        "Provide the Payment Block Hash and Payment Extrinsic Index printed after the original payment.",
-        "ridges resume-upload --file agent.py --payment-block-hash 0x87d2... --payment-extrinsic-index 7",
+        "Provide the Payment Quote ID, Payment Block Hash, and Payment Extrinsic Index printed after the original payment.",
+        "ridges resume-upload --file agent.py --quote-id 2f3b... --payment-block-hash 0x87d2... --payment-extrinsic-index 7",
     ),
 )
 @click.option("--file", help="Path to agent.py file")
@@ -488,6 +512,7 @@ def team_upload(
     "--openrouter-management-key",
     help="OpenRouter management key. Falls back to RIDGES_OPENROUTER_MANAGEMENT_KEY or an interactive prompt.",
 )
+@click.option("--quote-id", required=True, help="Payment Quote ID printed after the original payment.")
 @click.option("--payment-block-hash", required=True, help="Payment Block Hash printed after the original payment.")
 @click.option(
     "--payment-extrinsic-index",
@@ -503,6 +528,7 @@ def resume_upload(
     hotkey_name: Optional[str],
     openrouter_api_key: Optional[str],
     openrouter_management_key: Optional[str],
+    quote_id: str,
     payment_block_hash: str,
     payment_extrinsic_index: int,
 ):
@@ -517,12 +543,14 @@ def resume_upload(
     receipt = PaymentReceipt(
         block_hash=payment_block_hash,
         extrinsic_index=payment_extrinsic_index,
-        payment_time=time.time(),
+        quote_id=quote_id,
     )
 
     try:
         with httpx.Client() as client:
-            _execute_upload(client, wallet=wallet, target=target, credentials=credentials, receipt=receipt)
+            _execute_upload(
+                client, wallet=wallet, target=target, credentials=credentials, receipt=receipt, run_check=False
+            )
 
     except click.ClickException:
         raise

--- a/miners/cli/commands/upload.py
+++ b/miners/cli/commands/upload.py
@@ -542,7 +542,10 @@ def resume_upload(
     quote_id = quote_id or Prompt.ask("Payment Quote ID")
     payment_block_hash = payment_block_hash or Prompt.ask("Payment Block Hash")
     if payment_extrinsic_index is None:
-        payment_extrinsic_index = int(Prompt.ask("Payment Extrinsic Index"))
+        try:
+            payment_extrinsic_index = int(Prompt.ask("Payment Extrinsic Index"))
+        except ValueError:
+            raise click.ClickException("Payment Extrinsic Index must be an integer") from None
 
     receipt = PaymentReceipt(
         block_hash=payment_block_hash,

--- a/models/payments.py
+++ b/models/payments.py
@@ -9,6 +9,7 @@ class Payment(BaseModel):
     payment_block_hash: str
     payment_extrinsic_index: str
 
+    quote_id: Optional[UUID] = None
     agent_id: Optional[UUID] = None
 
     miner_hotkey: str
@@ -16,3 +17,12 @@ class Payment(BaseModel):
     amount_rao: int
 
     created_at: datetime
+
+
+class PaymentQuote(BaseModel):
+    quote_id: UUID
+    miner_hotkey: str
+    amount_rao: int
+    send_address: str
+    created_at: datetime
+    expires_at: datetime

--- a/models/upload.py
+++ b/models/upload.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class AgentUploadResponse(BaseModel):
+    """Response model for successful agent upload"""
+
+    status: str = Field(..., description="Status of the upload operation")
+    message: str = Field(..., description="Detailed message about the upload result")
+
+
+class UploadPriceResponse(BaseModel):
+    """Response model for upload pricing"""
+
+    amount_rao: int = Field(..., description="Amount to send for evaluation (in RAO)")
+    send_address: str = Field(..., description="TAO address to send evaluation payment to")
+
+
+class AgentCheckResponse(AgentUploadResponse):
+    """Response model for successful agent upload preflight checks"""
+
+    quote_id: UUID = Field(..., description="Quote ID to include when uploading or resuming")
+    amount_rao: int = Field(..., description="Amount to send for evaluation (in RAO)")
+    send_address: str = Field(..., description="TAO address to send evaluation payment to")
+    expires_at: datetime = Field(..., description="Latest on-chain payment timestamp accepted for this quote")
+
+
+class ErrorResponse(BaseModel):
+    """Error response model"""
+
+    detail: str = Field(..., description="Error message describing what went wrong")

--- a/queries/payments.py
+++ b/queries/payments.py
@@ -1,7 +1,8 @@
+from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from models.payments import Payment
+from models.payments import Payment, PaymentQuote
 from utils.database import DatabaseConnection, db_operation
 
 
@@ -13,7 +14,8 @@ async def reserve_payment(
     miner_hotkey: str,
     miner_coldkey: str,
     amount_rao: int,
-) -> Payment:
+    quote_id: Optional[UUID] = None,
+) -> Optional[Payment]:
     """Reserve a payment for an upload agent operation. It creates a new payment record with the given details, but with a NULL agent_id or it retrieves an existing payment row. The payment is considered reserved until the agent_id is set, which happens when the upload is completed.
 
     Parameters
@@ -30,10 +32,12 @@ async def reserve_payment(
         Coldkey of the miner.
     amount_rao : int
         Amount of RAO associated with the payment.
+    quote_id : Optional[UUID], optional
+        Server-issued upload payment quote used to validate the payment.
 
     Returns
     -------
-    Payment
+    Optional[Payment]
         Payment row corresponding to the reserved payment. If a payment with the same block hash and extrinsic index already exists, it returns that payment instead of creating a new one.
     """
     await conn.execute(
@@ -44,15 +48,17 @@ async def reserve_payment(
             agent_id,
             miner_hotkey,
             miner_coldkey,
-            amount_rao
-        ) VALUES ($1, $2, NULL, $3, $4, $5)
-        ON CONFLICT (payment_block_hash, payment_extrinsic_index) DO NOTHING
+            amount_rao,
+            quote_id
+        ) VALUES ($1, $2, NULL, $3, $4, $5, $6)
+        ON CONFLICT DO NOTHING
         """,
         payment_block_hash,
         payment_extrinsic_index,
         miner_hotkey,
         miner_coldkey,
         amount_rao,
+        quote_id,
     )
     return await retrieve_payment_by_hash(
         payment_block_hash=payment_block_hash,
@@ -118,3 +124,49 @@ async def retrieve_payment_by_hash(
         return None
 
     return Payment(**result)
+
+
+@db_operation
+async def create_payment_quote(
+    conn: DatabaseConnection,
+    miner_hotkey: str,
+    amount_rao: int,
+    send_address: str,
+    expires_at: datetime,
+) -> PaymentQuote:
+    result = await conn.fetchrow(
+        """
+        INSERT INTO upload_payment_quotes (
+            miner_hotkey,
+            amount_rao,
+            send_address,
+            expires_at
+        ) VALUES ($1, $2, $3, $4)
+        RETURNING *
+        """,
+        miner_hotkey,
+        amount_rao,
+        send_address,
+        expires_at,
+    )
+    return PaymentQuote(**result)
+
+
+@db_operation
+async def retrieve_payment_quote(
+    conn: DatabaseConnection,
+    quote_id: UUID,
+) -> Optional[PaymentQuote]:
+    result = await conn.fetchrow(
+        """
+        SELECT *
+        FROM upload_payment_quotes
+        WHERE quote_id = $1
+        """,
+        quote_id,
+    )
+
+    if result is None:
+        return None
+
+    return PaymentQuote(**result)

--- a/tests/api/test_openrouter_secrets.py
+++ b/tests/api/test_openrouter_secrets.py
@@ -152,7 +152,16 @@ def _patch_upload_dependencies(
         return None
 
     async def fake_get_upload_price(*args, **kwargs):
-        return SimpleNamespace(amount_rao=1)
+        return SimpleNamespace(amount_rao=1, send_address="send-address")
+
+    async def fake_create_payment_quote(*, miner_hotkey: str, amount_rao: int, send_address: str, expires_at):
+        return SimpleNamespace(
+            quote_id=uuid4(),
+            miner_hotkey=miner_hotkey,
+            amount_rao=amount_rao,
+            send_address=send_address,
+            expires_at=expires_at,
+        )
 
     monkeypatch.setattr(upload_endpoint, "validate_openrouter_keys", fake_validate_openrouter_keys)
     monkeypatch.setattr(upload_endpoint, "get_hotkey_lock", fake_get_hotkey_lock)
@@ -166,6 +175,7 @@ def _patch_upload_dependencies(
     monkeypatch.setattr(upload_endpoint, "check_hotkey_registered", fake_check_hotkey_registered)
     monkeypatch.setattr(upload_endpoint, "check_agent_banned", fake_check_agent_banned)
     monkeypatch.setattr(upload_endpoint, "get_upload_price", fake_get_upload_price)
+    monkeypatch.setattr(upload_endpoint, "create_payment_quote", fake_create_payment_quote)
     monkeypatch.setattr(upload_endpoint, "create_agent", create_agent_impl)
     return upload_endpoint
 
@@ -428,7 +438,6 @@ async def test_post_agent_encrypts_both_openrouter_keys_and_persists_metadata(mo
         name="Agent",
         payment_block_hash="block",
         payment_extrinsic_index="0",
-        payment_time=0.0,
         openrouter_api_key="sk-or-v1-runtime",
         openrouter_management_key="sk-or-v1-management",
     )
@@ -466,7 +475,6 @@ async def test_check_agent_uses_shared_openrouter_validation(monkeypatch) -> Non
         file_info="miner-hotkey:1",
         signature="sig",
         name="Agent",
-        payment_time=0.0,
         openrouter_api_key="sk-or-v1-runtime",
         openrouter_management_key="sk-or-v1-management",
     )

--- a/tests/api/test_upload.py
+++ b/tests/api/test_upload.py
@@ -6,7 +6,8 @@ One container starts per module; tables are truncated between tests.
 """
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -26,6 +27,7 @@ FAKE_COLDKEY = "5FColdKey456"
 FAKE_AMOUNT_RAO = 100_000_000
 FAKE_SEND_ADDRESS = "5FUploadWalletAddress"
 FAKE_OWNER_HOTKEY = upload_module.config.OWNER_HOTKEY
+FAKE_BLOCK_TIME = datetime(2026, 6, 9, 18, 0, tzinfo=timezone.utc)
 
 # ── fixtures ──────────────────────────────────────────────────────────────────
 
@@ -47,7 +49,7 @@ async def clean_tables(postgres_db):
     yield
     async with _db.pool.acquire() as conn:
         await conn.execute(
-            "TRUNCATE evaluation_payments, agents, failed_upload_refunds, upload_attempts RESTART IDENTITY CASCADE"
+            "TRUNCATE evaluation_payments, upload_payment_quotes, agents, failed_upload_refunds, upload_attempts RESTART IDENTITY CASCADE"
         )
 
 
@@ -84,16 +86,34 @@ def _make_upload_file(
     return f
 
 
+def _make_fake_timestamp_extrinsic() -> MagicMock:
+    ext = MagicMock()
+    ext.value_serialized = {
+        "call": {
+            "call_module": "Timestamp",
+            "call_function": "set",
+            "call_args": [
+                {"name": "now", "value": int(FAKE_BLOCK_TIME.timestamp() * 1000)},
+            ],
+        }
+    }
+    return ext
+
+
 def _make_fake_extrinsic(coldkey: str, amount_rao: int, dest: str) -> MagicMock:
     ext = MagicMock()
-    ext.value = {
+    ext.value_serialized = {
+        "address": coldkey,
         "call": {
+            "call_module": "Balances",
+            "call_function": "transfer_keep_alive",
             "call_args": [
                 {"name": "dest", "value": dest},
                 {"name": "value", "value": amount_rao},
-            ]
-        }
+            ],
+        },
     }
+    ext.value = ext.value_serialized
     ext.__getitem__ = MagicMock(side_effect=lambda key: coldkey if key == "address" else None)
     return ext
 
@@ -110,15 +130,16 @@ def _install_mocks(monkeypatch) -> None:
     )
     monkeypatch.setattr(
         upload_module.subtensor_client,
-        "get_block",
+        "get_block_info",
         AsyncMock(
-            return_value={
-                "header": {"number": 42},
-                "extrinsics": [
-                    MagicMock(),
+            return_value=SimpleNamespace(
+                number=42,
+                timestamp=int(FAKE_BLOCK_TIME.timestamp() * 1000),
+                extrinsics=[
+                    _make_fake_timestamp_extrinsic(),
                     _make_fake_extrinsic(FAKE_COLDKEY, FAKE_AMOUNT_RAO, FAKE_SEND_ADDRESS),
                 ],
-            }
+            )
         ),
     )
     monkeypatch.setattr(
@@ -127,9 +148,14 @@ def _install_mocks(monkeypatch) -> None:
         AsyncMock(return_value=FAKE_COLDKEY),
     )
     monkeypatch.setattr(
+        upload_module.subtensor_client,
+        "get_balance",
+        AsyncMock(return_value=MagicMock(rao=FAKE_AMOUNT_RAO * 10)),
+    )
+    monkeypatch.setattr(
         upload_module,
         "get_upload_price",
-        AsyncMock(return_value=MagicMock(amount_rao=FAKE_AMOUNT_RAO)),
+        AsyncMock(return_value=MagicMock(amount_rao=FAKE_AMOUNT_RAO, send_address=FAKE_SEND_ADDRESS)),
     )
     monkeypatch.setattr("queries.agent.upload_text_file_to_s3", AsyncMock())
     response_validate_open_router_keys = MagicMock()
@@ -146,7 +172,38 @@ def _install_mocks(monkeypatch) -> None:
     )
 
 
-async def _call_post_agent(hotkey: str = FAKE_HOTKEY, name: str = "test-agent") -> AgentUploadResponse:
+async def _insert_quote(
+    *,
+    hotkey: str = FAKE_HOTKEY,
+    amount_rao: int = FAKE_AMOUNT_RAO,
+    send_address: str = FAKE_SEND_ADDRESS,
+    created_at: datetime = FAKE_BLOCK_TIME - timedelta(minutes=1),
+    expires_at: datetime = FAKE_BLOCK_TIME + timedelta(minutes=15),
+) -> uuid.UUID:
+    quote_id = uuid.uuid4()
+    async with _db.pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO upload_payment_quotes
+                (quote_id, miner_hotkey, amount_rao, send_address, created_at, expires_at)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            """,
+            quote_id,
+            hotkey,
+            amount_rao,
+            send_address,
+            created_at,
+            expires_at,
+        )
+    return quote_id
+
+
+async def _call_post_agent(
+    hotkey: str = FAKE_HOTKEY,
+    name: str = "test-agent",
+    quote_id: uuid.UUID | None = None,
+    include_quote: bool = True,
+) -> AgentUploadResponse:
     """Call the post agent endpoint with the given hotkey and name, using default mocks for all blockchain and S3 interactions.
 
     Parameters
@@ -161,6 +218,9 @@ async def _call_post_agent(hotkey: str = FAKE_HOTKEY, name: str = "test-agent") 
     AgentUploadResponse
         The response from the agent upload endpoint.
     """
+    if quote_id is None and include_quote and hotkey != FAKE_OWNER_HOTKEY:
+        quote_id = await _insert_quote(hotkey=hotkey)
+
     return await upload_module.post_agent(
         request=_make_request(),
         agent_file=_make_upload_file(),
@@ -170,7 +230,9 @@ async def _call_post_agent(hotkey: str = FAKE_HOTKEY, name: str = "test-agent") 
         name=name,
         payment_block_hash=FAKE_BLOCK_HASH,
         payment_extrinsic_index=FAKE_EXTRINSIC_INDEX,
-        payment_time=0.0,
+        quote_id=str(quote_id) if quote_id is not None else None,
+        openrouter_api_key="sk-or-v1-runtime",
+        openrouter_management_key="sk-or-v1-management",
     )
 
 
@@ -192,9 +254,43 @@ async def _call_post_agent_as_owner() -> AgentUploadResponse:
 
 
 @pytest.mark.anyio
+async def test_check_agent_persists_payment_quote():
+    """Preflight stores the server-side amount and destination for later payment validation."""
+    response = await upload_module.check_agent_post(
+        request=_make_request(),
+        agent_file=_make_upload_file(),
+        public_key="deadbeef",
+        file_info=f"{FAKE_HOTKEY}:0",
+        signature="fakesig",
+        name="test-agent",
+        openrouter_api_key="sk-or-v1-runtime",
+        openrouter_management_key="sk-or-v1-management",
+    )
+
+    assert response.status == "success"
+    assert response.amount_rao == FAKE_AMOUNT_RAO
+    assert response.send_address == FAKE_SEND_ADDRESS
+
+    async with _db.pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT miner_hotkey, amount_rao, send_address, expires_at, created_at
+            FROM upload_payment_quotes
+            WHERE quote_id = $1
+            """,
+            response.quote_id,
+        )
+    assert row["miner_hotkey"] == FAKE_HOTKEY
+    assert row["amount_rao"] == FAKE_AMOUNT_RAO
+    assert row["send_address"] == FAKE_SEND_ADDRESS
+    assert row["expires_at"] > row["created_at"]
+
+
+@pytest.mark.anyio
 async def test_fresh_upload_creates_completed_payment():
     """Happy path: payment row is created and linked to the deterministic agent_id."""
-    response = await _call_post_agent()
+    quote_id = await _insert_quote()
+    response = await _call_post_agent(quote_id=quote_id)
 
     assert response.status == "success"
     payment = await retrieve_payment_by_hash(
@@ -203,6 +299,7 @@ async def test_fresh_upload_creates_completed_payment():
     )
     assert payment is not None
     assert payment.agent_id == _deterministic_id()
+    assert payment.quote_id == quote_id
 
 
 @pytest.mark.anyio
@@ -210,10 +307,11 @@ async def test_same_receipt_twice_raises_402():
     """A payment receipt already linked to an agent is rejected with 402."""
     from fastapi import HTTPException
 
-    await _call_post_agent()
+    quote_id = await _insert_quote()
+    await _call_post_agent(quote_id=quote_id)
 
     with pytest.raises(HTTPException) as exc_info:
-        await _call_post_agent()
+        await _call_post_agent(quote_id=quote_id)
 
     assert exc_info.value.status_code == 402
 
@@ -224,21 +322,23 @@ async def test_partial_failure_retry_succeeds():
     A prior attempt reserved the payment (agent_id=NULL) but crashed before
     creating the agent. The retry detects the incomplete row and finishes the upload.
     """
+    quote_id = await _insert_quote()
     async with _db.pool.acquire() as conn:
         await conn.execute(
             """
             INSERT INTO evaluation_payments
-                (payment_block_hash, payment_extrinsic_index, agent_id, miner_hotkey, miner_coldkey, amount_rao)
-            VALUES ($1, $2, NULL, $3, $4, $5)
+                (payment_block_hash, payment_extrinsic_index, agent_id, miner_hotkey, miner_coldkey, amount_rao, quote_id)
+            VALUES ($1, $2, NULL, $3, $4, $5, $6)
             """,
             FAKE_BLOCK_HASH,
             FAKE_EXTRINSIC_INDEX,
             FAKE_HOTKEY,
             FAKE_COLDKEY,
             FAKE_AMOUNT_RAO,
+            quote_id,
         )
 
-    response = await _call_post_agent()
+    response = await _call_post_agent(quote_id=quote_id)
 
     assert response.status == "success"
     payment = await retrieve_payment_by_hash(
@@ -288,14 +388,10 @@ async def test_amount_mismatch_raises_402(monkeypatch):
     """A payment with the wrong on-chain amount is rejected before reservation."""
     from fastapi import HTTPException
 
-    monkeypatch.setattr(
-        upload_module,
-        "get_upload_price",
-        AsyncMock(return_value=MagicMock(amount_rao=FAKE_AMOUNT_RAO + 1)),
-    )
+    quote_id = await _insert_quote(amount_rao=FAKE_AMOUNT_RAO + 1)
 
     with pytest.raises(HTTPException) as exc_info:
-        await _call_post_agent()
+        await _call_post_agent(quote_id=quote_id)
 
     assert exc_info.value.status_code == 402
     payment = await retrieve_payment_by_hash(
@@ -303,6 +399,48 @@ async def test_amount_mismatch_raises_402(monkeypatch):
         payment_extrinsic_index=FAKE_EXTRINSIC_INDEX,
     )
     assert payment is None
+
+
+@pytest.mark.anyio
+async def test_missing_quote_id_raises_clean_400():
+    """Old clients are rejected with a clear error instead of stale pricing behavior."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_post_agent(include_quote=False)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == upload_module.OUTDATED_UPLOAD_CLIENT_MESSAGE
+
+
+@pytest.mark.anyio
+async def test_quote_for_different_hotkey_raises_402():
+    """A quote is bound to the miner hotkey that requested it."""
+    from fastapi import HTTPException
+
+    quote_id = await _insert_quote(hotkey="5OtherHotkey")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_post_agent(quote_id=quote_id)
+
+    assert exc_info.value.status_code == 402
+
+
+@pytest.mark.anyio
+async def test_payment_outside_quote_window_raises_402():
+    """The on-chain payment timestamp, not upload wall-clock time, must fit the quote window."""
+    from fastapi import HTTPException
+
+    quote_id = await _insert_quote(
+        created_at=FAKE_BLOCK_TIME + timedelta(minutes=1),
+        expires_at=FAKE_BLOCK_TIME + timedelta(minutes=15),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_post_agent(quote_id=quote_id)
+
+    assert exc_info.value.status_code == 402
+    assert exc_info.value.detail == "Payment was made outside the quote validity window"
 
 
 @pytest.mark.anyio

--- a/tests/miners/test_upload_command.py
+++ b/tests/miners/test_upload_command.py
@@ -42,9 +42,13 @@ def test_resolve_openrouter_upload_credentials_uses_env_then_prompt(monkeypatch)
 
 
 class _FakeResponse:
-    def __init__(self, status_code: int, text: str = "ok") -> None:
+    def __init__(self, status_code: int, text: str = "ok", json_data: dict | None = None) -> None:
         self.status_code = status_code
         self.text = text
+        self._json_data = json_data or {}
+
+    def json(self) -> dict:
+        return self._json_data
 
 
 class _FakeClient:
@@ -52,13 +56,19 @@ class _FakeClient:
         self.response = response
         self.calls: list[dict] = []
 
-    def post(self, url: str, *, files, data, timeout):
-        self.calls.append({"url": url, "files": files, "data": data, "timeout": timeout})
+    def post(self, url: str, *, files=None, data=None, json=None, timeout=None):
+        self.calls.append({"url": url, "files": files, "data": data, "json": json, "timeout": timeout})
         return self.response
 
 
 def test_check_upload_allowed_sends_both_openrouter_keys(tmp_path: Path) -> None:
-    client = _FakeClient(_FakeResponse(200))
+    quote_response = {
+        "quote_id": "quote-123",
+        "amount_rao": 123,
+        "send_address": "5Send",
+        "expires_at": "2026-06-10T00:00:00Z",
+    }
+    client = _FakeClient(_FakeResponse(200, json_data=quote_response))
     target = upload_module.UploadTarget(
         api_url="https://agent-upload.ridges.ai",
         agent_path=tmp_path / "agent.py",
@@ -77,11 +87,13 @@ def test_check_upload_allowed_sends_both_openrouter_keys(tmp_path: Path) -> None
         management_key="sk-or-v1-management",
     )
 
-    upload_module._check_upload_allowed(client, target=target, pending=pending, credentials=credentials)
+    quote = upload_module._check_upload_allowed(client, target=target, pending=pending, credentials=credentials)
 
+    assert quote == quote_response
     assert len(client.calls) == 1
     assert client.calls[0]["data"]["openrouter_api_key"] == "sk-or-v1-runtime"
     assert client.calls[0]["data"]["openrouter_management_key"] == "sk-or-v1-management"
+    assert "payment_time" not in client.calls[0]["data"]
 
 
 def test_upload_payload_includes_both_openrouter_keys() -> None:
@@ -95,7 +107,7 @@ def test_upload_payload_includes_both_openrouter_keys() -> None:
     receipt = upload_module.PaymentReceipt(
         block_hash="0xabc",
         extrinsic_index=5,
-        payment_time=123.45,
+        quote_id="quote-123",
     )
     credentials = upload_module.OpenRouterUploadCredentials(
         runtime_api_key="sk-or-v1-runtime",
@@ -110,3 +122,5 @@ def test_upload_payload_includes_both_openrouter_keys() -> None:
 
     assert payload["openrouter_api_key"] == "sk-or-v1-runtime"
     assert payload["openrouter_management_key"] == "sk-or-v1-management"
+    assert payload["quote_id"] == "quote-123"
+    assert "payment_time" not in payload

--- a/utils/bittensor.py
+++ b/utils/bittensor.py
@@ -7,6 +7,7 @@ from bittensor_wallet.keypair import Keypair
 import api.config as config
 
 if TYPE_CHECKING:
+    from bittensor.core.types import BlockInfo
     from bittensor.utils.balance import Balance
 
 logger = logging.getLogger(__name__)
@@ -120,6 +121,11 @@ class SubtensorClient:
         """
         assert self._subtensor is not None, "Subtensor client is not initialized"
         return await self._subtensor.substrate.get_block(block_hash=block_hash)
+
+    async def get_block_info(self, block_hash: str) -> "BlockInfo | None":
+        """Retrieve decoded block information by its hash."""
+        assert self._subtensor is not None, "Subtensor client is not initialized"
+        return await self._subtensor.get_block_info(block_hash=block_hash)
 
     async def get_events(self, block_hash: str) -> list:
         """Retrieve events for a given block hash.


### PR DESCRIPTION
Adds server-issued upload payment quotes for reliable resume-upload

## Description
This PR replaces client-provided upload pricing timestamps with server-issued payment quotes. `/upload/agent/check` now creates a quote containing the expected RAO amount, destination address, hotkey, and validity window. 
Upload and resume-upload then validate the on-chain payment against that quote instead of recomputing historical pricing.

This makes failed uploads resumable without relying on current TAO price or client-provided payment time.

## Changes

- Add `upload_payment_quotes` table and `quote_id` linkage on `evaluation_payments`.
- Return quote details from `/upload/agent/check`.
- Require `quote_id` for production miner uploads.
- Validate payment amount, destination, hotkey owner, and block timestamp against the quote.
- Allow reserved-but-incomplete payments to be completed by resume-upload.
- Update CLI upload flow to print and submit Payment Quote ID.
- Update resume-upload to accept or prompt for quote/payment receipt fields.
- Switch payment block lookup to Bittensor `get_block_info()`.
