### PR TITLE
feat: Track approved agents timeline

### DIFF
--- a/api/endpoints/evaluation_sets.py
+++ b/api/endpoints/evaluation_sets.py
@@ -261,7 +261,10 @@ async def _build_approved_agents(set_id: int) -> list[ApprovedAgent]:
             version_num=row["version_num"],
             created_at=row["created_at"],
             final_score=row["final_score"],
-            emission=0.0,  # TODO Set to zero until we start collecting emissions for approved agents
+            emission=0.0,
+            approved_at=row["approved_at"],
+            average_runtime_seconds=row["average_runtime_seconds"],
+            average_cost_usd=row["average_cost_usd"],
         )
         for row in agent_rows
     ]

--- a/api/endpoints/validator.py
+++ b/api/endpoints/validator.py
@@ -56,6 +56,7 @@ from queries.agent import (
 from queries.approval import finish_agent_and_enqueue_approval
 from queries.evaluation import (
     create_new_evaluation_and_evaluation_runs,
+    get_approved_leader_ranking_for_set,
     get_approved_validator_leader_score_for_set,
     get_evaluation_by_id,
     get_hydrated_evaluation_by_id,
@@ -1192,23 +1193,23 @@ async def handle_evaluation_if_finished(evaluation_id: UUID) -> None:
 
 
 async def _should_run_auto_approval_judge(*, agent_id: UUID, set_id: int) -> bool:
-    candidate_score = await get_validator_agent_score_for_set(
+    candidate = await get_validator_agent_score_for_set(
         agent_id,
         set_id,
         config.NUM_EVALS_PER_AGENT,
     )
-    if candidate_score is None:
+    if candidate is None:
         logger.warning(
             f"Skipping auto approval for agent_id={agent_id} set_id={set_id}: no complete validator score found"
         )
         return False
 
-    approved_leader_score = await get_approved_validator_leader_score_for_set(
+    leader = await get_approved_leader_ranking_for_set(
         set_id,
         agent_id,
         config.NUM_EVALS_PER_AGENT,
     )
-    if approved_leader_score is None:
+    if leader is None:
         return True
 
-    return candidate_score >= approved_leader_score
+    return candidate.beats(leader)

--- a/models/evaluation_set.py
+++ b/models/evaluation_set.py
@@ -156,3 +156,6 @@ class ApprovedAgent(BaseModel):
     created_at: datetime.datetime
     final_score: Float4
     emission: float
+    approved_at: datetime.datetime
+    average_runtime_seconds: Float4 | None
+    average_cost_usd: Float4 | None

--- a/queries/evaluation.py
+++ b/queries/evaluation.py
@@ -1,5 +1,6 @@
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from typing import List, Optional, Tuple
 from uuid import UUID, uuid4
 
@@ -204,31 +205,145 @@ async def get_approved_validator_leader_score_for_set(
     )
 
 
+@dataclass(slots=True, frozen=True)
+class AgentRankingProfile:
+    final_score: float
+    avg_cost_usd: Optional[float]
+    created_at: datetime
+
+    def beats(self, other: "AgentRankingProfile") -> bool:
+        """Check if an AgentRankingProfile instance can beat
+        another one.
+
+        It checks the following parameters in order:
+        - Final score
+        - Average cost throughout all eval runs
+        - Agent creation datetime
+
+        Parameters
+        ----------
+        other : AgentRankingProfile
+            Another AgentRankingProfile instance.
+        Returns
+        -------
+        bool
+            True if this instance beats the `other`, False if not.
+        """
+        if self.final_score > other.final_score:
+            return True
+        if self.final_score < other.final_score:
+            return False
+
+        s_cost = self.avg_cost_usd
+        o_cost = other.avg_cost_usd
+        if s_cost is not None and o_cost is not None:
+            if s_cost < o_cost:
+                return True
+            if s_cost > o_cost:
+                return False
+        elif s_cost is not None and o_cost is None:
+            return True
+        elif s_cost is None and o_cost is not None:
+            return False
+
+        if self.created_at < other.created_at:
+            return True
+
+        return False
+
+
+@db_operation
+async def get_approved_leader_ranking_for_set(
+    conn: DatabaseConnection,
+    set_id: int,
+    excluded_agent_id: UUID,
+    required_validator_count: int = config.NUM_EVALS_PER_AGENT,
+) -> Optional[AgentRankingProfile]:
+    row = await conn.fetchrow(
+        """
+        SELECT
+            ass.final_score,
+            rt.avg_cost_usd,
+            ass.created_at
+        FROM agent_scores ass
+        LEFT JOIN LATERAL (
+            SELECT AVG(eh.avg_cost_usd) AS avg_cost_usd
+            FROM evaluations_hydrated eh
+            WHERE eh.agent_id             = ass.agent_id
+              AND eh.set_id               = ass.set_id
+              AND eh.evaluation_set_group  = 'validator'::EvaluationSetGroup
+              AND eh.status               = 'success'::EvaluationStatus
+        ) rt ON true
+        WHERE ass.set_id = $1
+          AND ass.approved IS TRUE
+          AND ass.approved_at <= NOW()
+          AND ass.validator_count = $2
+          AND ass.status::text <> 'cancelled'
+          AND ass.agent_id <> $3
+          AND NOT EXISTS (
+              SELECT 1
+              FROM benchmark_agent_ids benchmark_agent
+              WHERE benchmark_agent.agent_id = ass.agent_id
+          )
+        ORDER BY ass.final_score DESC, rt.avg_cost_usd ASC NULLS LAST, ass.created_at ASC
+        LIMIT 1
+        """,
+        set_id,
+        required_validator_count,
+        excluded_agent_id,
+    )
+    if row is None:
+        return None
+    return AgentRankingProfile(
+        final_score=row["final_score"],
+        avg_cost_usd=row["avg_cost_usd"],
+        created_at=row["created_at"],
+    )
+
+
 @db_operation
 async def get_validator_agent_score_for_set(
     conn: DatabaseConnection,
     agent_id: UUID,
     set_id: int,
     required_validator_count: int = config.NUM_EVALS_PER_AGENT,
-) -> Optional[float]:
-    return await conn.fetchval(
+) -> Optional[AgentRankingProfile]:
+    row = await conn.fetchrow(
         """
-        SELECT agent_score.final_score
-        FROM agent_scores agent_score
-        WHERE agent_score.agent_id = $1
-          AND agent_score.set_id = $2
-          AND agent_score.validator_count = $3
-          AND agent_score.status::text <> 'cancelled'
+        SELECT
+            ass.final_score,
+            rt.avg_cost_usd,
+            ass.created_at
+        FROM agent_scores ass
+        LEFT JOIN LATERAL (
+            SELECT AVG(eh.avg_cost_usd) AS avg_cost_usd
+            FROM evaluations_hydrated eh
+            WHERE eh.agent_id             = ass.agent_id
+              AND eh.set_id               = ass.set_id
+              AND eh.evaluation_set_group  = 'validator'::EvaluationSetGroup
+              AND eh.status               = 'success'::EvaluationStatus
+        ) rt ON true
+        WHERE ass.agent_id = $1
+          AND ass.set_id = $2
+          AND ass.validator_count = $3
+          AND ass.status::text <> 'cancelled'
           AND NOT EXISTS (
               SELECT 1
               FROM benchmark_agent_ids benchmark_agent
-              WHERE benchmark_agent.agent_id = agent_score.agent_id
+              WHERE benchmark_agent.agent_id = ass.agent_id
           )
         LIMIT 1
         """,
         agent_id,
         set_id,
         required_validator_count,
+    )
+    if row is None:
+        return None
+    return AgentRankingProfile(
+        final_score=row["final_score"],
+        avg_cost_usd=row["avg_cost_usd"],
+        created_at=row["created_at"],
     )
 
 

--- a/queries/evaluation_set.py
+++ b/queries/evaluation_set.py
@@ -649,27 +649,37 @@ async def get_evaluation_set_leaderboard_summary(conn: DatabaseConnection, set_i
 @db_operation
 async def get_approved_agents_for_set(conn: DatabaseConnection, set_id: int) -> list[asyncpg.Record]:
     return await conn.fetch(
-        """
-        -- agent_scores has one row per agent; set_id tracks the most recent set.
-        -- Agents approved for this set but re-scored in a later set will not appear here.
+        f"""
+        WITH
+        approved_agent_ids AS (
+            SELECT aa.agent_id
+            FROM approved_agents aa
+            WHERE aa.set_id = $1
+              AND aa.agent_id NOT IN (SELECT agent_id FROM benchmark_agent_ids)
+        ),
+        {_sql_validator_metrics_cte(include_validator_hotkeys=False, agent_filter_cte="approved_agent_ids")}
         SELECT
             a.agent_id,
             a.miner_hotkey,
             a.name,
             a.version_num,
             a.created_at,
-            ass.final_score
+            ass.final_score,
+            aa.approved_at,
+            vm.average_cost_usd,
+            vm.average_runtime_seconds
         FROM approved_agents aa
         JOIN agents a ON a.agent_id = aa.agent_id
         JOIN agent_scores ass ON ass.agent_id = aa.agent_id AND ass.set_id = $1
         LEFT JOIN agent_final_review_statuses review
-        ON review.agent_id = aa.agent_id
-        AND review.set_id = aa.set_id
+            ON review.agent_id = aa.agent_id
+            AND review.set_id = aa.set_id
+        LEFT JOIN validator_metrics vm ON vm.agent_id = aa.agent_id
         WHERE aa.set_id = $1
           AND aa.agent_id NOT IN (SELECT agent_id FROM benchmark_agent_ids)
           AND ass.status = 'finished'
           AND review.approval_review_status is distinct from 'rejected'
-        ORDER BY ass.final_score DESC
+        ORDER BY aa.approved_at ASC
         """,
         set_id,
     )

--- a/queries/evaluation_set.py
+++ b/queries/evaluation_set.py
@@ -66,7 +66,7 @@ def _sql_agents_in_window_cte(select_columns: str) -> str:
     """
 
 
-def _sql_validator_metrics_cte(include_validator_hotkeys: bool) -> str:
+def _sql_validator_metrics_cte(include_validator_hotkeys: bool, agent_filter_cte: str = "agents_in_window") -> str:
     """This method returns a CTE that computes average validator cost and runtime per agent, over their 3 "valid" evaluations. A valid evaluation is one with the status set to 'success' or 'running' or that it was cancelled.
 
 
@@ -76,6 +76,8 @@ def _sql_validator_metrics_cte(include_validator_hotkeys: bool) -> str:
     ----------
     include_validator_hotkeys : bool
         Whether to include an array of validator hotkeys for the evaluations considered in the averages.
+    agent_filter_cte : str
+        Name of the CTE providing agent_id values to filter against. Defaults to "agents_in_window".
 
     Returns
     -------
@@ -145,7 +147,7 @@ def _sql_validator_metrics_cte(include_validator_hotkeys: bool) -> str:
         f"                evaluations.agent_id,\n"
         f"                evaluations.evaluation_id\n"
         f"        ) AS ranked\n"
-        f"        JOIN agents_in_window aiw ON aiw.agent_id = ranked.agent_id\n"
+        f"        JOIN {agent_filter_cte} aiw ON aiw.agent_id = ranked.agent_id\n"
         f"        where ranked.status in ('running', 'success') or ranked.cancelled is true\n"
         f"    ) AS sample\n"
         f"    WHERE sample.rn <= {NUM_EVALS_PER_AGENT}\n"

--- a/queries/evaluation_set.py
+++ b/queries/evaluation_set.py
@@ -658,6 +658,8 @@ async def get_approved_agents_for_set(conn: DatabaseConnection, set_id: int) -> 
               AND aa.agent_id NOT IN (SELECT agent_id FROM benchmark_agent_ids)
         ),
         {_sql_validator_metrics_cte(include_validator_hotkeys=False, agent_filter_cte="approved_agent_ids")}
+        -- agent_scores has one row per agent; set_id tracks the most recent set.
+        -- Agents approved for this set but re-scored in a later set will not appear here.
         SELECT
             a.agent_id,
             a.miner_hotkey,
@@ -679,7 +681,7 @@ async def get_approved_agents_for_set(conn: DatabaseConnection, set_id: int) -> 
           AND aa.agent_id NOT IN (SELECT agent_id FROM benchmark_agent_ids)
           AND ass.status = 'finished'
           AND review.approval_review_status is distinct from 'rejected'
-        ORDER BY aa.approved_at ASC
+        ORDER BY aa.approved_at DESC
         """,
         set_id,
     )

--- a/tests/api/test_auto_approval.py
+++ b/tests/api/test_auto_approval.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 import pytest
@@ -9,6 +9,7 @@ from api.endpoints import validator as validator_endpoint
 from models.agent import Agent, AgentStatus
 from models.evaluation import EvaluationStatus, HydratedEvaluation
 from models.evaluation_set import EvaluationSetGroup
+from queries.evaluation import AgentRankingProfile
 
 
 def _hydrated_evaluation(*, agent_id, set_id: int = 7) -> HydratedEvaluation:
@@ -150,41 +151,44 @@ async def test_handle_evaluation_finished_skips_auto_approval_for_non_leader_can
 @pytest.mark.anyio
 async def test_should_run_auto_approval_judge_when_no_approved_leader(monkeypatch) -> None:
     agent_id = uuid4()
+    now = datetime.now(timezone.utc)
 
     async def fake_get_validator_agent_score_for_set(_agent_id, _set_id, _required_validator_count):
-        return 0.61
+        return AgentRankingProfile(final_score=0.61, avg_cost_usd=0.05, created_at=now)
 
-    async def fake_get_approved_validator_leader_score_for_set(_set_id, _excluded_agent_id, _required_validator_count):
+    async def fake_get_approved_leader_ranking_for_set(_set_id, _excluded_agent_id, _required_validator_count):
         return None
 
     monkeypatch.setattr(validator_endpoint, "get_validator_agent_score_for_set", fake_get_validator_agent_score_for_set)
     monkeypatch.setattr(
         validator_endpoint,
-        "get_approved_validator_leader_score_for_set",
-        fake_get_approved_validator_leader_score_for_set,
+        "get_approved_leader_ranking_for_set",
+        fake_get_approved_leader_ranking_for_set,
     )
 
     assert await validator_endpoint._should_run_auto_approval_judge(agent_id=agent_id, set_id=11) is True
 
 
 @pytest.mark.anyio
-async def test_should_run_auto_approval_judge_allows_candidate_to_tie_approved_leader(monkeypatch) -> None:
+async def test_should_run_auto_approval_judge_rejects_full_tie_with_leader(monkeypatch) -> None:
     agent_id = uuid4()
+    now = datetime.now(timezone.utc)
+    profile = AgentRankingProfile(final_score=0.75, avg_cost_usd=0.05, created_at=now)
 
     async def fake_get_validator_agent_score_for_set(_agent_id, _set_id, _required_validator_count):
-        return 0.75
+        return profile
 
-    async def fake_get_approved_validator_leader_score_for_set(_set_id, _excluded_agent_id, _required_validator_count):
-        return 0.75
+    async def fake_get_approved_leader_ranking_for_set(_set_id, _excluded_agent_id, _required_validator_count):
+        return profile
 
     monkeypatch.setattr(validator_endpoint, "get_validator_agent_score_for_set", fake_get_validator_agent_score_for_set)
     monkeypatch.setattr(
         validator_endpoint,
-        "get_approved_validator_leader_score_for_set",
-        fake_get_approved_validator_leader_score_for_set,
+        "get_approved_leader_ranking_for_set",
+        fake_get_approved_leader_ranking_for_set,
     )
 
-    assert await validator_endpoint._should_run_auto_approval_judge(agent_id=agent_id, set_id=11) is True
+    assert await validator_endpoint._should_run_auto_approval_judge(agent_id=agent_id, set_id=11) is False
 
 
 @pytest.mark.anyio
@@ -230,3 +234,67 @@ async def test_handle_evaluation_finished_updates_status_without_auto_approval(m
         "agent_id": agent_id,
         "status": AgentStatus.finished,
     }
+
+
+@pytest.mark.anyio
+async def test_should_run_auto_approval_judge_accepts_candidate_with_lower_cost(monkeypatch) -> None:
+    agent_id = uuid4()
+    now = datetime.now(timezone.utc)
+
+    async def fake_get_validator_agent_score_for_set(_agent_id, _set_id, _required_validator_count):
+        return AgentRankingProfile(final_score=0.75, avg_cost_usd=0.03, created_at=now)
+
+    async def fake_get_approved_leader_ranking_for_set(_set_id, _excluded_agent_id, _required_validator_count):
+        return AgentRankingProfile(final_score=0.75, avg_cost_usd=0.05, created_at=now)
+
+    monkeypatch.setattr(validator_endpoint, "get_validator_agent_score_for_set", fake_get_validator_agent_score_for_set)
+    monkeypatch.setattr(
+        validator_endpoint,
+        "get_approved_leader_ranking_for_set",
+        fake_get_approved_leader_ranking_for_set,
+    )
+
+    assert await validator_endpoint._should_run_auto_approval_judge(agent_id=agent_id, set_id=11) is True
+
+
+@pytest.mark.anyio
+async def test_should_run_auto_approval_judge_rejects_candidate_with_higher_cost(monkeypatch) -> None:
+    agent_id = uuid4()
+    now = datetime.now(timezone.utc)
+
+    async def fake_get_validator_agent_score_for_set(_agent_id, _set_id, _required_validator_count):
+        return AgentRankingProfile(final_score=0.75, avg_cost_usd=0.08, created_at=now)
+
+    async def fake_get_approved_leader_ranking_for_set(_set_id, _excluded_agent_id, _required_validator_count):
+        return AgentRankingProfile(final_score=0.75, avg_cost_usd=0.05, created_at=now)
+
+    monkeypatch.setattr(validator_endpoint, "get_validator_agent_score_for_set", fake_get_validator_agent_score_for_set)
+    monkeypatch.setattr(
+        validator_endpoint,
+        "get_approved_leader_ranking_for_set",
+        fake_get_approved_leader_ranking_for_set,
+    )
+
+    assert await validator_endpoint._should_run_auto_approval_judge(agent_id=agent_id, set_id=11) is False
+
+
+@pytest.mark.anyio
+async def test_should_run_auto_approval_judge_rejects_newer_candidate_same_score_and_cost(monkeypatch) -> None:
+    agent_id = uuid4()
+    now = datetime.now(timezone.utc)
+    earlier = now - timedelta(hours=1)
+
+    async def fake_get_validator_agent_score_for_set(_agent_id, _set_id, _required_validator_count):
+        return AgentRankingProfile(final_score=0.75, avg_cost_usd=0.05, created_at=now)
+
+    async def fake_get_approved_leader_ranking_for_set(_set_id, _excluded_agent_id, _required_validator_count):
+        return AgentRankingProfile(final_score=0.75, avg_cost_usd=0.05, created_at=earlier)
+
+    monkeypatch.setattr(validator_endpoint, "get_validator_agent_score_for_set", fake_get_validator_agent_score_for_set)
+    monkeypatch.setattr(
+        validator_endpoint,
+        "get_approved_leader_ranking_for_set",
+        fake_get_approved_leader_ranking_for_set,
+    )
+
+    assert await validator_endpoint._should_run_auto_approval_judge(agent_id=agent_id, set_id=11) is False

--- a/tests/api/test_evaluation_sets.py
+++ b/tests/api/test_evaluation_sets.py
@@ -133,12 +133,20 @@ async def _insert_evaluations(conn, *, agent_id, set_id: int, set_groups: list[s
         await _insert_evaluation(conn, agent_id=agent_id, set_id=set_id, set_group=group)
 
 
-async def _insert_approved_agent(conn, *, agent_id, set_id: int) -> None:
-    await conn.execute(
-        "INSERT INTO approved_agents (agent_id, set_id) VALUES ($1, $2)",
-        agent_id,
-        set_id,
-    )
+async def _insert_approved_agent(conn, *, agent_id, set_id: int, approved_at: datetime | None = None) -> None:
+    if approved_at is not None:
+        await conn.execute(
+            "INSERT INTO approved_agents (agent_id, set_id, approved_at) VALUES ($1, $2, $3)",
+            agent_id,
+            set_id,
+            approved_at,
+        )
+    else:
+        await conn.execute(
+            "INSERT INTO approved_agents (agent_id, set_id) VALUES ($1, $2)",
+            agent_id,
+            set_id,
+        )
 
 
 async def _insert_agent_score(conn, *, agent_id, miner_hotkey: str, set_id: int, final_score: float) -> None:
@@ -605,6 +613,9 @@ async def test_evaluation_set_approved_agents_returns_empty_list(monkeypatch):
 async def test_evaluation_set_approved_agents_returns_approved_agents(monkeypatch):
     agent_id_a = uuid4()
     agent_id_b = uuid4()
+    approved_at_a = datetime(2026, 5, 1, 10, tzinfo=timezone.utc)
+    approved_at_b = datetime(2026, 5, 1, 8, tzinfo=timezone.utc)  # earlier — should appear first
+
     async with _db.pool.acquire() as conn:
         await _insert_eval_set(conn, set_id=1, created_at=SET_1_CREATED)
         await _insert_competition(conn, set_id=1, created_at=SET_1_CREATED)
@@ -624,21 +635,38 @@ async def test_evaluation_set_approved_agents_returns_approved_agents(monkeypatc
             created_at=AGENT_TS_SET_1,
             set_id=1,
         )
-        await _insert_approved_agent(conn, agent_id=agent_id_a, set_id=1)
-        await _insert_approved_agent(conn, agent_id=agent_id_b, set_id=1)
+        await _insert_approved_agent(conn, agent_id=agent_id_a, set_id=1, approved_at=approved_at_a)
+        await _insert_approved_agent(conn, agent_id=agent_id_b, set_id=1, approved_at=approved_at_b)
+
+        # Insert validator evaluations + runs so validator_metrics CTE can compute cost/runtime
+        eval_id_a = await _insert_evaluation(conn, agent_id=agent_id_a, set_id=1, set_group="validator")
+        await _insert_finished_evaluation_run(conn, evaluation_id=eval_id_a, cost_usd=0.5, runtime_seconds=120)
+        eval_id_b = await _insert_evaluation(conn, agent_id=agent_id_b, set_id=1, set_group="validator")
+        await _insert_finished_evaluation_run(conn, evaluation_id=eval_id_b, cost_usd=0.3, runtime_seconds=60)
+
+        # Insert agent_scores AFTER evaluations to avoid trigger-based refresh overwriting them
+        # (the refresh_agent_scores trigger fires on evaluation INSERT and clears manual scores)
         await _insert_agent_score(conn, agent_id=agent_id_a, miner_hotkey="hotkey-a", set_id=1, final_score=90.0)
         await _insert_agent_score(conn, agent_id=agent_id_b, miner_hotkey="hotkey-b", set_id=1, final_score=70.0)
 
     result = await evaluation_sets_endpoint.evaluation_set_approved_agents(set_id=1)
 
     assert len(result) == 2
-    # Ordered by final_score DESC
-    assert result[0].miner_hotkey == "hotkey-a"
-    assert result[0].final_score == 90.0
+    # Ordered by approved_at ASC (agent_b was approved earlier)
+    assert result[0].id == agent_id_b
+    assert result[0].miner_hotkey == "hotkey-b"
+    assert result[0].final_score == 70.0
     assert result[0].emission == 0.0
-    assert result[0].id == agent_id_a
-    assert result[1].miner_hotkey == "hotkey-b"
-    assert result[1].final_score == 70.0
+    assert result[0].approved_at == approved_at_b
+    assert result[0].average_cost_usd == 0.3
+    assert result[0].average_runtime_seconds == 60
+
+    assert result[1].id == agent_id_a
+    assert result[1].miner_hotkey == "hotkey-a"
+    assert result[1].final_score == 90.0
+    assert result[1].approved_at == approved_at_a
+    assert result[1].average_cost_usd == 0.5
+    assert result[1].average_runtime_seconds == 120
 
 
 @pytest.mark.anyio

--- a/tests/api/test_evaluation_sets.py
+++ b/tests/api/test_evaluation_sets.py
@@ -613,8 +613,8 @@ async def test_evaluation_set_approved_agents_returns_empty_list(monkeypatch):
 async def test_evaluation_set_approved_agents_returns_approved_agents(monkeypatch):
     agent_id_a = uuid4()
     agent_id_b = uuid4()
-    approved_at_a = datetime(2026, 5, 1, 10, tzinfo=timezone.utc)
-    approved_at_b = datetime(2026, 5, 1, 8, tzinfo=timezone.utc)  # earlier — should appear first
+    approved_at_a = datetime(2026, 5, 1, 10, tzinfo=timezone.utc)  # latest approved appears first
+    approved_at_b = datetime(2026, 5, 1, 8, tzinfo=timezone.utc)
 
     async with _db.pool.acquire() as conn:
         await _insert_eval_set(conn, set_id=1, created_at=SET_1_CREATED)
@@ -652,21 +652,21 @@ async def test_evaluation_set_approved_agents_returns_approved_agents(monkeypatc
     result = await evaluation_sets_endpoint.evaluation_set_approved_agents(set_id=1)
 
     assert len(result) == 2
-    # Ordered by approved_at ASC (agent_b was approved earlier)
-    assert result[0].id == agent_id_b
-    assert result[0].miner_hotkey == "hotkey-b"
-    assert result[0].final_score == 70.0
-    assert result[0].emission == 0.0
-    assert result[0].approved_at == approved_at_b
-    assert result[0].average_cost_usd == 0.3
-    assert result[0].average_runtime_seconds == 60
+    # Ordered by approved_at DESC (agent_a was the latest approved)
+    assert result[0].id == agent_id_a
+    assert result[0].miner_hotkey == "hotkey-a"
+    assert result[0].final_score == 90.0
+    assert result[0].approved_at == approved_at_a
+    assert result[0].average_cost_usd == 0.5
+    assert result[0].average_runtime_seconds == 120
 
-    assert result[1].id == agent_id_a
-    assert result[1].miner_hotkey == "hotkey-a"
-    assert result[1].final_score == 90.0
-    assert result[1].approved_at == approved_at_a
-    assert result[1].average_cost_usd == 0.5
-    assert result[1].average_runtime_seconds == 120
+    assert result[1].id == agent_id_b
+    assert result[1].miner_hotkey == "hotkey-b"
+    assert result[1].final_score == 70.0
+    assert result[1].emission == 0.0
+    assert result[1].approved_at == approved_at_b
+    assert result[1].average_cost_usd == 0.3
+    assert result[1].average_runtime_seconds == 60
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

This PR updates the `GET /api/evaluation-sets/{ID}/approved-agents` endpoint to return 3 new fields and order the results so that the newest approved agents come first. Updated response schema:

```json
[
  {
    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
    "miner_hotkey": "string",
    "name": "string",
    "version_num": 0,
    "created_at": "2026-06-22T16:47:20.487Z",
    "final_score": 0,
    "emission": 0,
    "approved_at": "2026-06-22T16:47:20.487Z", --new
    "average_runtime_seconds": 0, --new
    "average_cost_usd": 0 --new
  }
]
```
It also updates the `_should_run_auto_approval_judge` to match the `/scoring/weights` logic. This means that if a candidate agent and the current leader have the same score it will use the average cost as a tie breaker and if that's the same then it will use the agent creation datetime as a tie breaker.