### PR TITLE
Add k8s request fraction

### DIFF
--- a/ridges_harbor/k8s_environment.py
+++ b/ridges_harbor/k8s_environment.py
@@ -65,7 +65,9 @@ class KubernetesEnvironment(BaseEnvironment):
         kubeconfig_context: str | None = None,
         node_selector: dict[str, str] | None = None,
         service_account_name: str | None = None,
-        memory_limit_multiplier: float | None = None,
+        memory_limit_multiplier: float | None = 1.0,
+        memory_request_fraction: float = 1.0,
+        cpu_request_fraction: float = 1.0,
         labels: dict[str, str] | None = None,
         image_pull_secrets: list[str] | None = None,
         owner_pod_name: str | None = None,
@@ -91,9 +93,13 @@ class KubernetesEnvironment(BaseEnvironment):
         self._owner_pod_name = owner_pod_name
         self._owner_pod_uid = owner_pod_uid
 
-        # Resource sizing
-        self.cpu_request = str(task_env_config.cpus)
-        self.memory_request = f"{task_env_config.memory_mb}Mi"
+        # Resource sizing.
+        # Requests are scaled down via *_request_fraction to allow overcommit on
+        # I/O-bound LLM benchmark workloads (pods mostly wait on API responses).
+        # The memory limit is set to memory_mb * memory_limit_multiplier (default
+        # 1.0), matching Docker's compose limit and providing OOM protection.
+        self.cpu_request = str(round(max(task_env_config.cpus * cpu_request_fraction, 0.1), 3))
+        self.memory_request = f"{max(int(task_env_config.memory_mb * memory_request_fraction), 128)}Mi"
         self.ephemeral_storage_request = f"{task_env_config.storage_mb}Mi"
 
         if memory_limit_multiplier is not None and memory_limit_multiplier > 0:

--- a/ridges_harbor/k8s_environment.py
+++ b/ridges_harbor/k8s_environment.py
@@ -555,14 +555,14 @@ class KubernetesEnvironment(BaseEnvironment):
             for member in tar.getmembers():
                 if member.name == source_path or member.name.startswith(source_path.lstrip("/")):
                     member.name = target_path.name
-                    tar.extract(member, path=str(target_path.parent))
+                    tar.extract(member, path=str(target_path.parent), filter="data")
                     break
 
     def _extract_tar_all(self, tar_data: bytes, target_dir: Path) -> None:
         """Blocking: extract every member of an in-memory tar archive."""
         tar_buffer = io.BytesIO(tar_data)
         with tarfile.open(fileobj=tar_buffer, mode="r") as tar:
-            tar.extractall(path=str(target_dir))
+            tar.extractall(path=str(target_dir), filter="data")
 
     async def _wait_for_container_exec_ready(self, max_attempts: int = 60) -> None:
         for attempt in range(max_attempts):

--- a/ridges_harbor/k8s_environment.py
+++ b/ridges_harbor/k8s_environment.py
@@ -94,10 +94,6 @@ class KubernetesEnvironment(BaseEnvironment):
         self._owner_pod_uid = owner_pod_uid
 
         # Resource sizing.
-        # Requests are scaled down via *_request_fraction to allow overcommit on
-        # I/O-bound LLM benchmark workloads (pods mostly wait on API responses).
-        # The memory limit is set to memory_mb * memory_limit_multiplier (default
-        # 1.0), matching Docker's compose limit and providing OOM protection.
         self.cpu_request = str(round(max(task_env_config.cpus * cpu_request_fraction, 0.1), 3))
         self.memory_request = f"{max(int(task_env_config.memory_mb * memory_request_fraction), 128)}Mi"
         self.ephemeral_storage_request = f"{task_env_config.storage_mb}Mi"

--- a/ridges_harbor/k8s_environment.py
+++ b/ridges_harbor/k8s_environment.py
@@ -384,10 +384,7 @@ class KubernetesEnvironment(BaseEnvironment):
         await self._wait_for_container_exec_ready()
 
         source_path = Path(source_path)
-        tar_buffer = io.BytesIO()
-        with tarfile.open(fileobj=tar_buffer, mode="w") as tar:
-            tar.add(str(source_path), arcname=Path(target_path).name)
-        tar_buffer.seek(0)
+        payload = await asyncio.to_thread(self._build_tar_single_file, source_path, Path(target_path).name)
 
         target_dir = str(Path(target_path).parent)
         await self.exec(f"mkdir -p {shlex.quote(target_dir)}", user="root")
@@ -405,9 +402,7 @@ class KubernetesEnvironment(BaseEnvironment):
             tty=False,
             _preload_content=False,
         )
-        resp.write_stdin(tar_buffer.read())
-        resp.run_forever(timeout=1)
-        resp.close()
+        await asyncio.to_thread(self._write_tar_stream, resp, payload)
 
     @retry(stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, min=2, max=30), reraise=True)
     async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
@@ -415,12 +410,7 @@ class KubernetesEnvironment(BaseEnvironment):
         await self._wait_for_container_exec_ready()
 
         source_dir = Path(source_dir)
-        tar_buffer = io.BytesIO()
-        with tarfile.open(fileobj=tar_buffer, mode="w") as tar:
-            for item in source_dir.rglob("*"):
-                if item.is_file():
-                    tar.add(str(item), arcname=str(item.relative_to(source_dir)))
-        tar_buffer.seek(0)
+        payload = await asyncio.to_thread(self._build_tar_dir, source_dir)
 
         await self.exec(f"mkdir -p {shlex.quote(target_dir)}", user="root")
 
@@ -438,11 +428,9 @@ class KubernetesEnvironment(BaseEnvironment):
             _preload_content=False,
         )
         try:
-            resp.write_stdin(tar_buffer.read())
+            await asyncio.to_thread(self._write_tar_stream, resp, payload)
         except Exception as exc:
             raise RuntimeError(f"Failed to write tar data to Pod {self.pod_name}: {exc}") from exc
-        resp.run_forever(timeout=1)
-        resp.close()
 
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=10), reraise=True)
     async def download_file(self, source_path: str, target_path: Path | str) -> None:
@@ -464,20 +452,9 @@ class KubernetesEnvironment(BaseEnvironment):
             _preload_content=False,
         )
 
-        tar_data = b""
-        while resp.is_open():
-            resp.update(timeout=1)
-            if resp.peek_stdout():
-                chunk = resp.read_stdout()
-                tar_data += chunk.encode("utf-8", errors="surrogateescape") if isinstance(chunk, str) else chunk
+        tar_data, _stderr_data = await asyncio.to_thread(self._read_tar_stream, resp)
 
-        tar_buffer = io.BytesIO(tar_data)
-        with tarfile.open(fileobj=tar_buffer, mode="r") as tar:
-            for member in tar.getmembers():
-                if member.name == source_path or member.name.startswith(source_path.lstrip("/")):
-                    member.name = target_path.name
-                    tar.extract(member, path=str(target_path.parent))
-                    break
+        await asyncio.to_thread(self._extract_tar_member, tar_data, source_path, target_path)
 
     @retry(stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, min=2, max=30), reraise=True)
     async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
@@ -502,15 +479,7 @@ class KubernetesEnvironment(BaseEnvironment):
         except ApiException as exc:
             raise RuntimeError(f"Failed to start tar download from Pod {self.pod_name}: {exc}") from exc
 
-        tar_data = b""
-        stderr_data = ""
-        while resp.is_open():
-            resp.update(timeout=1)
-            if resp.peek_stdout():
-                chunk = resp.read_stdout()
-                tar_data += chunk.encode("utf-8", errors="surrogateescape") if isinstance(chunk, str) else chunk
-            if resp.peek_stderr():
-                stderr_data += resp.read_stderr()
+        tar_data, stderr_data = await asyncio.to_thread(self._read_tar_stream, resp)
 
         if stderr_data and ("No such file or directory" in stderr_data or "cannot cd" in stderr_data):
             raise RuntimeError(f"Failed to access directory {source_dir} in Pod {self.pod_name}: {stderr_data.strip()}")
@@ -518,15 +487,19 @@ class KubernetesEnvironment(BaseEnvironment):
         if not tar_data:
             raise RuntimeError(f"No data received when downloading {source_dir} from Pod {self.pod_name}")
 
-        tar_buffer = io.BytesIO(tar_data)
         try:
-            with tarfile.open(fileobj=tar_buffer, mode="r") as tar:
-                tar.extractall(path=str(target_dir))
+            await asyncio.to_thread(self._extract_tar_all, tar_data, target_dir)
         except tarfile.TarError as exc:
             raise RuntimeError(f"Failed to extract {source_dir} from Pod {self.pod_name}: {exc}") from exc
 
     # ------------------------------------------------------------------
     # Private helpers
+    #
+    # These run blocking WebSocket stream I/O and tarfile (de)serialization,
+    # so they're always invoked via asyncio.to_thread rather than awaited
+    # directly -- calling them on the event loop would stall it for the
+    # entire transfer, starving heartbeats and other concurrent evaluation
+    # runs.
     # ------------------------------------------------------------------
 
     def _read_exec_output(self, resp: Any) -> tuple[str, str]:
@@ -539,6 +512,57 @@ class KubernetesEnvironment(BaseEnvironment):
             if resp.peek_stderr():
                 stderr += resp.read_stderr()
         return stdout, stderr
+
+    def _read_tar_stream(self, resp: Any) -> tuple[bytes, str]:
+        """Blocking: drain a WebSocket exec stream, returning (stdout_bytes, stderr_text)."""
+        tar_data = b""
+        stderr_data = ""
+        while resp.is_open():
+            resp.update(timeout=1)
+            if resp.peek_stdout():
+                chunk = resp.read_stdout()
+                tar_data += chunk.encode("utf-8", errors="surrogateescape") if isinstance(chunk, str) else chunk
+            if resp.peek_stderr():
+                stderr_data += resp.read_stderr()
+        return tar_data, stderr_data
+
+    def _write_tar_stream(self, resp: Any, payload: bytes) -> None:
+        """Blocking: write payload to the exec stream stdin and drain until closed."""
+        resp.write_stdin(payload)
+        resp.run_forever(timeout=1)
+        resp.close()
+
+    def _build_tar_single_file(self, source_path: Path, arcname: str) -> bytes:
+        """Blocking: build an in-memory tar archive containing a single file."""
+        tar_buffer = io.BytesIO()
+        with tarfile.open(fileobj=tar_buffer, mode="w") as tar:
+            tar.add(str(source_path), arcname=arcname)
+        return tar_buffer.getvalue()
+
+    def _build_tar_dir(self, source_dir: Path) -> bytes:
+        """Blocking: build an in-memory tar archive of every file under source_dir."""
+        tar_buffer = io.BytesIO()
+        with tarfile.open(fileobj=tar_buffer, mode="w") as tar:
+            for item in source_dir.rglob("*"):
+                if item.is_file():
+                    tar.add(str(item), arcname=str(item.relative_to(source_dir)))
+        return tar_buffer.getvalue()
+
+    def _extract_tar_member(self, tar_data: bytes, source_path: str, target_path: Path) -> None:
+        """Blocking: extract a single named member from an in-memory tar archive."""
+        tar_buffer = io.BytesIO(tar_data)
+        with tarfile.open(fileobj=tar_buffer, mode="r") as tar:
+            for member in tar.getmembers():
+                if member.name == source_path or member.name.startswith(source_path.lstrip("/")):
+                    member.name = target_path.name
+                    tar.extract(member, path=str(target_path.parent))
+                    break
+
+    def _extract_tar_all(self, tar_data: bytes, target_dir: Path) -> None:
+        """Blocking: extract every member of an in-memory tar archive."""
+        tar_buffer = io.BytesIO(tar_data)
+        with tarfile.open(fileobj=tar_buffer, mode="r") as tar:
+            tar.extractall(path=str(target_dir))
 
     async def _wait_for_container_exec_ready(self, max_attempts: int = 60) -> None:
         for attempt in range(max_attempts):

--- a/ridges_harbor/k8s_environment.py
+++ b/ridges_harbor/k8s_environment.py
@@ -967,6 +967,9 @@ class RidgesKubernetesEnvironment(KubernetesEnvironment):
                 )
             ],
             volume_mounts=[k8s_client.V1VolumeMount(name="context", mount_path="/workspace")],
+            resources=k8s_client.V1ResourceRequirements(
+                requests={"cpu": "100m", "memory": "256Mi"},
+            ),
         )
 
         kaniko_args = [
@@ -997,6 +1000,9 @@ class RidgesKubernetesEnvironment(KubernetesEnvironment):
             image="gcr.io/kaniko-project/executor:latest",
             args=kaniko_args,
             volume_mounts=kaniko_volume_mounts,
+            resources=k8s_client.V1ResourceRequirements(
+                requests={"cpu": "700m", "memory": "1536Mi"},
+            ),
         )
 
         volumes = [

--- a/ridges_harbor/runner.py
+++ b/ridges_harbor/runner.py
@@ -185,6 +185,9 @@ async def _run_task_dir(
 
         from validator.config import (
             K8S_CONTEXT,
+            K8S_CPU_REQUEST_FRACTION,
+            K8S_MEMORY_LIMIT_MULTIPLIER,
+            K8S_MEMORY_REQUEST_FRACTION,
             K8S_NAMESPACE,
             K8S_NODE_SELECTOR,
             K8S_REGISTRY,
@@ -228,6 +231,9 @@ async def _run_task_dir(
                 "registry_insecure": K8S_REGISTRY_INSECURE,
                 "owner_pod_name": K8S_OWNER_POD_NAME,
                 "owner_pod_uid": K8S_OWNER_POD_UID,
+                "memory_limit_multiplier": K8S_MEMORY_LIMIT_MULTIPLIER,
+                "memory_request_fraction": K8S_MEMORY_REQUEST_FRACTION,
+                "cpu_request_fraction": K8S_CPU_REQUEST_FRACTION,
             },
         )
 

--- a/utils/k8s.py
+++ b/utils/k8s.py
@@ -42,11 +42,10 @@ def cleanup_harbor_k8s_resources() -> None:
     """Delete orphaned eval Pods at startup.
 
     Safe in multi-screener deployments: only deletes pods owned by this
-    screener (stale UID) or pods with no owner reference (legacy).
+    screener (by pod name) or pods with no owner reference (legacy).
     """
     namespace = os.getenv("K8S_NAMESPACE", "ridges")
     my_pod_name = os.getenv("MY_POD_NAME")
-    my_pod_uid = os.getenv("MY_POD_UID")
     api = _get_core_api()
 
     logger.info("Cleaning up stale K8s eval Pods...")
@@ -63,11 +62,11 @@ def cleanup_harbor_k8s_resources() -> None:
         if not owner_refs:
             # Legacy pod with no owner reference -- always clean up.
             pass
-        elif my_pod_name and my_pod_uid:
-            # Delete only if an owner ref points to this screener with a stale UID.
-            dominated_by_us = any(ref.name == my_pod_name and ref.uid != my_pod_uid for ref in owner_refs)
+        elif my_pod_name:
+            # Delete if any owner ref points to this screener pod (by name).
+            dominated_by_us = any(ref.name == my_pod_name for ref in owner_refs)
             if not dominated_by_us:
-                continue  # Owned by a different screener, or current UID matches.
+                continue  # Owned by a different screener.
         else:
             # No Downward API vars available (local dev?) -- skip pods with owners.
             continue

--- a/validator/config.py
+++ b/validator/config.py
@@ -250,6 +250,17 @@ if RIDGES_ENVIRONMENT_TYPE == "kubernetes":
     K8S_REGISTRY_PASSWORD = os.getenv("K8S_REGISTRY_PASSWORD")  # for HEAD check Basic Auth
     K8S_REGISTRY_INSECURE = os.getenv("K8S_REGISTRY_INSECURE", "true").lower() == "true"
 
+# Resource overcommit knobs for K8s eval pods.
+# Requests are scaled down from the task's memory_mb/cpus so the scheduler can
+# pack more pods onto a node (LLM benchmark workloads are mostly I/O-bound and
+# burst rarely).  The limit always matches memory_mb (multiplier=1.0) so pods
+# get OOM-killed before starving the node, same as Docker's compose limit.
+#   Prod (24 GB, 20 pods): fraction=0.25 → 1 GB request, 4 GB limit → fits 20 pods
+#   Local dev:             fraction=0.1  → ~400 MB request → fits 15+ pods
+K8S_MEMORY_REQUEST_FRACTION: float = float(os.getenv("K8S_MEMORY_REQUEST_FRACTION", "0.25"))
+K8S_CPU_REQUEST_FRACTION: float = float(os.getenv("K8S_CPU_REQUEST_FRACTION", "0.25"))
+K8S_MEMORY_LIMIT_MULTIPLIER: float = float(os.getenv("K8S_MEMORY_LIMIT_MULTIPLIER", "1.0"))
+
 logger.info(f"Execution Backend: {RIDGES_ENVIRONMENT_TYPE}")
 
 logger.info("===============================")

--- a/validator/config.py
+++ b/validator/config.py
@@ -249,17 +249,9 @@ if RIDGES_ENVIRONMENT_TYPE == "kubernetes":
     K8S_REGISTRY_SECRET = os.getenv("K8S_REGISTRY_SECRET")  # e.g. "registry-creds"
     K8S_REGISTRY_PASSWORD = os.getenv("K8S_REGISTRY_PASSWORD")  # for HEAD check Basic Auth
     K8S_REGISTRY_INSECURE = os.getenv("K8S_REGISTRY_INSECURE", "true").lower() == "true"
-
-# Resource overcommit knobs for K8s eval pods.
-# Requests are scaled down from the task's memory_mb/cpus so the scheduler can
-# pack more pods onto a node (LLM benchmark workloads are mostly I/O-bound and
-# burst rarely).  The limit always matches memory_mb (multiplier=1.0) so pods
-# get OOM-killed before starving the node, same as Docker's compose limit.
-#   Prod (24 GB, 20 pods): fraction=0.25 → 1 GB request, 4 GB limit → fits 20 pods
-#   Local dev:             fraction=0.1  → ~400 MB request → fits 15+ pods
-K8S_MEMORY_REQUEST_FRACTION: float = float(os.getenv("K8S_MEMORY_REQUEST_FRACTION", "0.25"))
-K8S_CPU_REQUEST_FRACTION: float = float(os.getenv("K8S_CPU_REQUEST_FRACTION", "0.25"))
-K8S_MEMORY_LIMIT_MULTIPLIER: float = float(os.getenv("K8S_MEMORY_LIMIT_MULTIPLIER", "1.0"))
+    K8S_MEMORY_REQUEST_FRACTION: float = float(os.getenv("K8S_MEMORY_REQUEST_FRACTION", "0.25"))
+    K8S_CPU_REQUEST_FRACTION: float = float(os.getenv("K8S_CPU_REQUEST_FRACTION", "0.25"))
+    K8S_MEMORY_LIMIT_MULTIPLIER: float = float(os.getenv("K8S_MEMORY_LIMIT_MULTIPLIER", "1.0"))
 
 logger.info(f"Execution Backend: {RIDGES_ENVIRONMENT_TYPE}")
 

--- a/validator/main.py
+++ b/validator/main.py
@@ -1,5 +1,6 @@
 # NOTE ADAM: Subtensor bug (self.disable_third_party_loggers())
 import asyncio
+import concurrent.futures
 import logging
 import os
 import pathlib
@@ -730,6 +731,12 @@ async def main():
     global execution_engine
 
     setup_logging()
+    asyncio.get_running_loop().set_default_executor(
+        concurrent.futures.ThreadPoolExecutor(
+            max_workers=max(64, config.MAX_CONCURRENT_EVALUATION_RUNS * 2 + 32),
+            thread_name_prefix="validator-worker",
+        )
+    )
     await _run_startup_tasks()
 
     # Register with the Ridges platform, yielding us a session ID


### PR DESCRIPTION
# Changes

- Fix Docker/K8s memory_mb semantics mismatch by making CPU/memory requests configurable fractions of task limits, allowing overcommit locally while keeping prod safety
- Add CPU/memory requests to Kaniko build job containers
- Fix orphaned eval pods surviving screener container restarts
- Move blocking K8s exec/tar upload/download I/O off the event loop onto threads
- Enlarge the default thread pool at startup to stop long-lived exec-stream threads from starving heartbeat/cancellation-check requests