### PR TITLE
Update/cleaning janitor running

### DIFF
--- a/tests/test_docker_janitor.py
+++ b/tests/test_docker_janitor.py
@@ -72,7 +72,9 @@ class FakeImage:
 
 
 class FakeClient:
-    def __init__(self, containers=None, networks=None, images=None, *, vanished_container_ids=(), vanished_image_ids=()):
+    def __init__(
+        self, containers=None, networks=None, images=None, *, vanished_container_ids=(), vanished_image_ids=()
+    ):
         self._containers = containers or []
         self._networks = networks or []
         self._images = images or []
@@ -122,9 +124,7 @@ class FakeClient:
                 return [c.summary() for c in result]
 
             def images(self):
-                return [
-                    {"Id": i.id, "RepoTags": list(i.tags) if i.tags is not None else None} for i in client._images
-                ]
+                return [{"Id": i.id, "RepoTags": list(i.tags) if i.tags is not None else None} for i in client._images]
 
             def prune_builds(self):
                 client.pruned_builds = True

--- a/tests/test_docker_janitor.py
+++ b/tests/test_docker_janitor.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from docker.errors import NotFound as docker_errors_NotFound
 
 import utils.docker as docker_utils
 from utils.docker import (
@@ -19,6 +20,7 @@ def _iso(age: timedelta) -> str:
 
 class FakeContainer:
     def __init__(self, name, status, *, labeled=True, age=timedelta(hours=2), image_id="sha256:aaa"):
+        self.id = f"id-{name}"
         self.name = name
         self.status = status
         self.labels = {TRIAL_LABEL: "t123"} if labeled else {}
@@ -30,6 +32,17 @@ class FakeContainer:
 
     def remove(self, force=False):
         self.removed = True
+
+    def summary(self):
+        """The bulk /containers/json representation of this container."""
+        names = self.summary_names if getattr(self, "summary_names", None) else [f"/{self.name}"]
+        return {
+            "Id": self.id,
+            "Names": names,
+            "ImageID": self.attrs.get("ImageID"),
+            "Image": self.attrs.get("Image"),
+            "Labels": self.labels,
+        }
 
 
 class FakeNetwork:
@@ -59,10 +72,12 @@ class FakeImage:
 
 
 class FakeClient:
-    def __init__(self, containers=None, networks=None, images=None):
+    def __init__(self, containers=None, networks=None, images=None, *, vanished_container_ids=(), vanished_image_ids=()):
         self._containers = containers or []
         self._networks = networks or []
         self._images = images or []
+        self.vanished_container_ids = set(vanished_container_ids)
+        self.vanished_image_ids = set(vanished_image_ids)
         self.removed_tags = []
         self.pruned_images = False
         self.pruned_builds = False
@@ -70,19 +85,26 @@ class FakeClient:
         client = self
 
         class Containers:
-            def list(self, all=False, filters=None):
-                result = client._containers
-                if filters and "label" in filters:
-                    result = [c for c in result if filters["label"] in c.labels]
-                return list(result)
+            def get(self, container_id):
+                if container_id in client.vanished_container_ids:
+                    raise docker_errors_NotFound(f"No such container: {container_id}")
+                for c in client._containers:
+                    if c.id == container_id or c.name == container_id:
+                        return c
+                raise docker_errors_NotFound(f"No such container: {container_id}")
 
         class Networks:
             def list(self):
                 return list(client._networks)
 
         class Images:
-            def list(self):
-                return list(client._images)
+            def get(self, image_id):
+                if image_id in client.vanished_image_ids:
+                    raise docker_errors_NotFound(f"No such image: {image_id}")
+                for i in client._images:
+                    if i.id == image_id:
+                        return i
+                raise docker_errors_NotFound(f"No such image: {image_id}")
 
             def remove(self, tag, force=False, noprune=False):
                 assert force is False and noprune is True
@@ -90,12 +112,23 @@ class FakeClient:
 
             def prune(self, filters=None):
                 client.pruned_images = True
-                return {"SpaceReclaimed": 0}
+                return {"SpaceReclaimed": 123}
 
         class Api:
+            def containers(self, all=False, filters=None):
+                result = client._containers
+                if filters and "label" in filters:
+                    result = [c for c in result if filters["label"] in c.labels]
+                return [c.summary() for c in result]
+
+            def images(self):
+                return [
+                    {"Id": i.id, "RepoTags": list(i.tags) if i.tags is not None else None} for i in client._images
+                ]
+
             def prune_builds(self):
                 client.pruned_builds = True
-                return {"SpaceReclaimed": 0}
+                return {"SpaceReclaimed": 456}
 
         self.containers = Containers()
         self.networks = Networks()
@@ -107,6 +140,7 @@ class FakeClient:
 def inject_client(monkeypatch):
     def _inject(client):
         monkeypatch.setattr(docker_utils, "docker_client", client)
+        monkeypatch.setattr(docker_utils, "docker_client_long_timeout", client)
         return client
 
     return _inject
@@ -316,7 +350,8 @@ def test_future_last_tag_time_kept(inject_client):
 
 
 def test_reference_via_inspect_image_key_protects(inject_client):
-    """Inspect-format containers expose the image id under 'Image', not 'ImageID'."""
+    """Bulk summaries carry an 'Image' reference field alongside 'ImageID';
+    either key protecting a referenced image keeps the belt-and-braces guard."""
     referenced = FakeImage("sha256:ref", ["task__x__abc-main:latest"], last_tag_age=timedelta(hours=12))
     holder = FakeContainer("task__x__abc-main-1", "exited")
     holder.attrs = {"Created": holder.attrs["Created"], "Image": "sha256:ref"}
@@ -332,6 +367,26 @@ def test_image_dry_run_counts_without_removing(inject_client):
 
     assert _sweep_images(dry_run=True) == 1
     assert client.removed_tags == []
+
+
+def test_image_sweep_survives_image_vanishing_mid_sweep(inject_client):
+    """An image deleted between the bulk listing and its inspect must not abort the sweep."""
+    ghost = FakeImage("sha256:ghost", ["task__x__ghost-main:latest"], last_tag_age=timedelta(hours=12))
+    leaked = FakeImage("sha256:leak", ["task__x__abc-main:latest"], last_tag_age=timedelta(hours=12))
+    client = inject_client(FakeClient(images=[ghost, leaked], vanished_image_ids={"sha256:ghost"}))
+
+    assert _sweep_images() == 1
+    assert client.removed_tags == ["task__x__abc-main:latest"]
+
+
+def test_container_sweep_survives_container_vanishing_mid_sweep(inject_client):
+    """A container deleted between the bulk listing and its inspect must not abort the sweep."""
+    ghost = FakeContainer("task__x__ghost-main-1", "exited")
+    stale = FakeContainer("task__x__abc-main-1", "exited")
+    inject_client(FakeClient(containers=[ghost, stale], vanished_container_ids={ghost.id}))
+
+    assert _sweep_containers() == 1
+    assert stale.removed and not ghost.removed
 
 
 # --- pressure-gated cache prune ---------------------------------------------
@@ -352,3 +407,55 @@ def test_cache_prune_dry_run_never_prunes(inject_client):
 
     prune_caches_under_disk_pressure(disk_used_percent=95, pressure_percent=80, dry_run=True)
     assert not client.pruned_images and not client.pruned_builds
+
+
+def test_cache_prune_returns_reclaim_summary(inject_client):
+    inject_client(FakeClient())
+
+    below = prune_caches_under_disk_pressure(disk_used_percent=50, pressure_percent=80, dry_run=False)
+    assert below == {"fired": False, "image_bytes": 0, "build_bytes": 0, "errors": 0}
+
+    fired = prune_caches_under_disk_pressure(disk_used_percent=95, pressure_percent=80, dry_run=False)
+    assert fired == {"fired": True, "image_bytes": 123, "build_bytes": 456, "errors": 0}
+
+
+def test_long_timeout_client_fallback_is_not_cached(monkeypatch):
+    """A transient init failure must not pin the short-timeout default client forever."""
+    default_client = object()
+    monkeypatch.setattr(docker_utils, "docker_client", default_client)
+    monkeypatch.setattr(docker_utils, "docker_client_long_timeout", None)
+
+    def failing_from_env(timeout=None):
+        raise RuntimeError("daemon hiccup")
+
+    monkeypatch.setattr(docker_utils.docker, "from_env", failing_from_env)
+    assert docker_utils.get_long_timeout_docker_client() is default_client
+    assert docker_utils.docker_client_long_timeout is None  # fallback not cached
+
+    long_client = object()
+    monkeypatch.setattr(docker_utils.docker, "from_env", lambda timeout=None: long_client)
+    assert docker_utils.get_long_timeout_docker_client() is long_client  # retried and cached
+    assert docker_utils.docker_client_long_timeout is long_client
+
+
+# --- bulk-summary edge cases -------------------------------------------------
+
+
+def test_image_sweep_tolerates_null_repo_tags(inject_client):
+    """Bulk /images/json may report RepoTags as null; the sweep must skip safely."""
+    untagged = FakeImage("sha256:none", None, last_tag_age=timedelta(hours=12))
+    leaked = FakeImage("sha256:leak", ["task__x__abc-main:latest"], last_tag_age=timedelta(hours=12))
+    client = inject_client(FakeClient(images=[untagged, leaked]))
+
+    assert _sweep_images() == 1
+    assert client.removed_tags == ["task__x__abc-main:latest"]
+
+
+def test_container_sweep_matches_when_alias_precedes_primary_name(inject_client):
+    """Names ordering is not guaranteed; an alias listed first must not hide a candidate."""
+    stale = FakeContainer("task__x__abc-main-1", "exited")
+    stale.summary_names = ["/other/link-alias", "/task__x__abc-main-1"]
+    inject_client(FakeClient(containers=[stale]))
+
+    assert _sweep_containers() == 1
+    assert stale.removed

--- a/utils/docker.py
+++ b/utils/docker.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import subprocess
 from datetime import datetime, timezone
@@ -16,6 +17,17 @@ RIDGES_TRIAL_ID_LABEL = "ridges.trial_id"
 
 
 docker_client = None
+docker_client_long_timeout = None
+
+
+def get_prune_timeout_seconds() -> int:
+    """Client timeout for prune operations, which can run for minutes on a
+    backlogged daemon (docker-py's 60s default would abandon them mid-flight).
+    """
+    try:
+        return max(60, int(os.getenv("CLEANUP_PRUNE_TIMEOUT_SECONDS", "1800")))
+    except ValueError:
+        return 1800
 
 
 def _initialize_docker():
@@ -33,6 +45,20 @@ def get_docker_client():
         _initialize_docker()
 
     return docker_client
+
+
+def get_long_timeout_docker_client():
+    """A docker client for slow bulk operations (prunes); lazily initialised."""
+
+    global docker_client_long_timeout
+    if docker_client_long_timeout is None:
+        try:
+            docker_client_long_timeout = docker.from_env(timeout=get_prune_timeout_seconds())
+        except Exception as e:
+            logger.warning(f"Failed to initialize long-timeout Docker client, falling back to default: {e}")
+            return get_docker_client()
+
+    return docker_client_long_timeout
 
 
 def build_docker_image(dockerfile_dir: str, tag: str) -> None:
@@ -117,7 +143,7 @@ def cleanup_harbor_docker_resources() -> None:
 
 
 def prune_docker_disk_resources(*, include_build_cache: bool = False) -> None:
-    docker_client = get_docker_client()
+    docker_client = get_long_timeout_docker_client()
 
     logger.info("Pruning dangling Docker images...")
     try:
@@ -184,13 +210,20 @@ def sweep_stale_harbor_containers(
     removed = 0
 
     try:
-        candidates = docker_client.containers.list(all=True, filters={"label": RIDGES_TRIAL_ID_LABEL})
+        summaries = docker_client.api.containers(all=True, filters={"label": RIDGES_TRIAL_ID_LABEL})
     except Exception as e:
         logger.warning(f"Janitor: failed to list containers: {e}")
         return 0
 
-    for container in candidates:
+    for summary in summaries:
+        names = [n.lstrip("/") for n in (summary.get("Names") or [])]
+        name = names[0] if names else (summary.get("Id") or "")[:12]
         try:
+            if not any(HARBOR_CONTAINER_NAME_PATTERN.fullmatch(n) for n in names):
+                continue
+
+            container = docker_client.containers.get(summary.get("Id") or name)
+            name = container.name
             if not HARBOR_CONTAINER_NAME_PATTERN.fullmatch(container.name):
                 continue
 
@@ -223,7 +256,7 @@ def sweep_stale_harbor_containers(
         except docker.errors.NotFound:
             continue
         except Exception as e:
-            logger.warning(f"Janitor: failed to remove container {container.name}: {e}")
+            logger.warning(f"Janitor: failed to remove container {name}: {e}")
 
     try:
         networks = docker_client.networks.list()
@@ -269,27 +302,33 @@ def sweep_leaked_harbor_images(*, tag_grace_sec: float, dry_run: bool) -> int:
     removed = 0
 
     try:
-        referenced_image_ids = set()
-        for container in docker_client.containers.list(all=True):
-            for key in ("ImageID", "Image"):
-                value = container.attrs.get(key)
-                if value:
-                    referenced_image_ids.add(value)
-        images = docker_client.images.list()
+        container_summaries = docker_client.api.containers(all=True)
+        image_summaries = docker_client.api.images()
     except Exception as e:
         logger.warning(f"Janitor: failed to list images/containers: {e}")
         return 0
 
-    for image in images:
+    referenced_image_ids = set()
+    for summary in container_summaries:
+        for key in ("ImageID", "Image"):
+            value = summary.get(key)
+            if value:
+                referenced_image_ids.add(value)
+
+    for summary in image_summaries:
+        image_id = summary.get("Id") or ""
         try:
             harbor_tags = [
-                tag for tag in (image.tags or []) if HARBOR_IMAGE_REPO_PATTERN.fullmatch(tag.rsplit(":", 1)[0])
+                tag
+                for tag in (summary.get("RepoTags") or [])
+                if HARBOR_IMAGE_REPO_PATTERN.fullmatch(tag.rsplit(":", 1)[0])
             ]
             if not harbor_tags:
                 continue
-            if image.id in referenced_image_ids:
+            if image_id in referenced_image_ids:
                 continue
 
+            image = docker_client.images.get(image_id)
             last_tag_time = _parse_docker_time((image.attrs.get("Metadata") or {}).get("LastTagTime"))
             age = _age_seconds(last_tag_time, now)
             if age is None or age <= tag_grace_sec:
@@ -306,33 +345,44 @@ def sweep_leaked_harbor_images(*, tag_grace_sec: float, dry_run: bool) -> int:
         except docker.errors.NotFound:
             continue
         except Exception as e:
-            logger.warning(f"Janitor: failed to remove image {image.id[:19]}: {e}")
+            logger.warning(f"Janitor: failed to remove image {image_id[:19]}: {e}")
 
     return removed
 
 
-def prune_caches_under_disk_pressure(*, disk_used_percent: float, pressure_percent: float, dry_run: bool) -> None:
-    """Aggressively prune build caches, but only when disk usage is at or above the threshold."""
-    if disk_used_percent < pressure_percent:
-        return
+def prune_caches_under_disk_pressure(*, disk_used_percent: float, pressure_percent: float, dry_run: bool) -> dict:
+    """Aggressively prune build caches, but only when disk usage is at or above the threshold.
 
-    docker_client = get_docker_client()
+    Returns a summary dict so the caller can log the outcome.
+    """
+    summary = {"fired": False, "image_bytes": 0, "build_bytes": 0, "errors": 0}
+    if disk_used_percent < pressure_percent:
+        return summary
+
+    summary["fired"] = True
+    docker_client = get_long_timeout_docker_client()
     logger.info(f"Janitor: disk at {disk_used_percent:.0f}% (threshold {pressure_percent:.0f}%), pruning caches...")
     if dry_run:
         logger.info("Janitor (dry-run): would prune dangling images (until=1h) and the build cache")
-        return
+        return summary
 
     try:
         result = docker_client.images.prune(filters={"dangling": True, "until": "1h"})
-        logger.info(f"Janitor: reclaimed {result.get('SpaceReclaimed', 0)} byte(s) from dangling images")
+        summary["image_bytes"] = result.get("SpaceReclaimed", 0) or 0
+        logger.info(f"Janitor: reclaimed {summary['image_bytes']} byte(s) from dangling images")
     except Exception as e:
+        summary["errors"] += 1
         logger.warning(f"Janitor: failed to prune dangling images: {e}")
 
     try:
         result = docker_client.api.prune_builds()
-        logger.info(f"Janitor: reclaimed {result.get('SpaceReclaimed', 0)} byte(s) from the build cache")
+        summary["build_bytes"] = result.get("SpaceReclaimed", 0) or 0
+        logger.info(f"Janitor: reclaimed {summary['build_bytes']} byte(s) from the build cache")
     except Exception as e:
+        summary["errors"] += 1
         logger.warning(f"Janitor: failed to prune build cache: {e}")
+
+    return summary
 
 
 def create_internal_docker_network(name: str) -> None:

--- a/validator/background_loops.py
+++ b/validator/background_loops.py
@@ -129,13 +129,22 @@ async def cleanup_loop(active_task_digests: Set[str]):
 
             try:
                 metrics = await get_system_metrics()
-                if metrics.disk_percent is not None:
-                    await asyncio.to_thread(
+                if metrics.disk_percent is None:
+                    logger.warning("Janitor: skipping pressure prune (disk metrics unavailable)")
+                else:
+                    prune_summary = await asyncio.to_thread(
                         prune_caches_under_disk_pressure,
                         disk_used_percent=metrics.disk_percent,
                         pressure_percent=config.CLEANUP_DISK_PRESSURE_PERCENT,
                         dry_run=dry_run,
                     )
+                    if prune_summary.get("fired"):
+                        logger.info(
+                            f"Janitor: pressure prune at {metrics.disk_percent:.0f}% disk reclaimed "
+                            f"{prune_summary.get('image_bytes', 0) / 1e6:.0f} MB (images) + "
+                            f"{prune_summary.get('build_bytes', 0) / 1e6:.0f} MB (build cache), "
+                            f"errors={prune_summary.get('errors', 0)} (dry_run={dry_run})"
+                        )
             except Exception as e:
                 logger.warning(f"Janitor cache prune failed (best-effort): {type(e).__name__}: {e}")
 

--- a/validator/config.py
+++ b/validator/config.py
@@ -5,6 +5,7 @@ import re
 from bittensor_wallet.wallet import Wallet
 from dotenv import load_dotenv
 
+from utils.docker import get_prune_timeout_seconds
 from utils.logger import setup_logging
 from utils.validator_hotkeys import validator_hotkey_to_name
 
@@ -230,13 +231,14 @@ CLEANUP_DOCKER_DRY_RUN = os.getenv("CLEANUP_DOCKER_DRY_RUN", "false").lower() ==
 CLEANUP_STOPPED_GRACE_MINUTES = max(5, int(os.getenv("CLEANUP_STOPPED_GRACE_MINUTES", "45")))
 CLEANUP_RUNNING_TTL_HOURS = max(2, int(os.getenv("CLEANUP_RUNNING_TTL_HOURS", "4")))
 CLEANUP_IMAGE_TAG_GRACE_HOURS = max(1, int(os.getenv("CLEANUP_IMAGE_TAG_GRACE_HOURS", "6")))
-CLEANUP_DISK_PRESSURE_PERCENT = min(100, max(50, int(os.getenv("CLEANUP_DISK_PRESSURE_PERCENT", "80"))))
+CLEANUP_DISK_PRESSURE_PERCENT = min(100, max(50, int(os.getenv("CLEANUP_DISK_PRESSURE_PERCENT", "75"))))
 if CLEANUP_ENABLED and CLEANUP_DOCKER_ENABLED:
     logger.info(f"Docker Janitor: dry_run={CLEANUP_DOCKER_DRY_RUN}")
     logger.info(f"Docker Janitor Stopped-Container Grace: {CLEANUP_STOPPED_GRACE_MINUTES} minute(s)")
     logger.info(f"Docker Janitor Running-Container TTL: {CLEANUP_RUNNING_TTL_HOURS} hour(s)")
     logger.info(f"Docker Janitor Image Tag Grace: {CLEANUP_IMAGE_TAG_GRACE_HOURS} hour(s)")
     logger.info(f"Docker Janitor Disk Pressure Threshold: {CLEANUP_DISK_PRESSURE_PERCENT}%")
+    logger.info(f"Docker Janitor Prune Timeout: {get_prune_timeout_seconds()} second(s)")
 
 # --- Environment Backend ---
 RIDGES_ENVIRONMENT_TYPE = os.getenv("RIDGES_ENVIRONMENT_TYPE", "docker")


### PR DESCRIPTION
- Janitor sweeps no longer abort when a container/image vanishes mid-listing (bulk API + per-item tolerance)
- Prunes use a long-timeout docker client (CLEANUP_PRUNE_TIMEOUT_SECONDS, default 1800s) - the 60s default abandoned large reclaims, letting disk pile up
- Pressure-prune results now logged via the validator logger; threshold default 80% -> 75%
