### PR TITLE
Fix: multi-line error log entries

### DIFF
--- a/api/endpoints/validator.py
+++ b/api/endpoints/validator.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import re
 import time
-import traceback
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from functools import wraps
@@ -745,9 +744,9 @@ async def _maybe_grant_retry(
         new_attempt = await create_next_attempt_and_reset_evaluation_run(evaluation_run.evaluation_run_id)
     except Exception as exc:
         logger.error(
-            f"Failed to grant retry for evaluation run {evaluation_run.evaluation_run_id}: {type(exc).__name__}: {exc}"
+            f"Failed to grant retry for evaluation run {evaluation_run.evaluation_run_id}: {type(exc).__name__}: {exc}",
+            exc_info=True,
         )
-        logger.error(traceback.format_exc())
         return None
 
     logger.info(f"Granted retry for evaluation run {evaluation_run.evaluation_run_id}")
@@ -1107,9 +1106,9 @@ async def validator_update_evaluation_run(
             except Exception as exc:
                 evaluation_id = getattr(current_evaluation, "evaluation_id", "unknown")
                 logger.error(
-                    f"Failed to run score-bound pruning for evaluation {evaluation_id}: {type(exc).__name__}: {exc}"
+                    f"Failed to run score-bound pruning for evaluation {evaluation_id}: {type(exc).__name__}: {exc}",
+                    exc_info=True,
                 )
-                logger.error(traceback.format_exc())
 
     response = ValidatorUpdateEvaluationRunResponse()
     if request.updated_status == EvaluationRunStatus.error:

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -93,9 +93,7 @@ tools = [
             "description": "Read the contents of a file",
             "parameters": {
                 "type": "object",
-                "properties": {
-                    "path": {"type": "string", "description": "Path to the file"}
-                },
+                "properties": {"path": {"type": "string", "description": "Path to the file"}},
                 "required": ["path"],
             },
         },

--- a/execution/failure_classifier.py
+++ b/execution/failure_classifier.py
@@ -147,12 +147,12 @@ def classify_trial_failure(
     if runtime_failure is not None:
         return ClassifiedExecutionFailure(
             error_code=map_runtime_failure_code(runtime_failure=runtime_failure),
-            detail=runtime_failure.model_dump_json(indent=2),
+            detail=runtime_failure.model_dump_json(),
         )
 
     return ClassifiedExecutionFailure(
         error_code=map_trial_exception_code(trial_result=trial_result, trial_exception=trial_exception),
-        detail=trial_exception.model_dump_json(indent=2),
+        detail=trial_exception.model_dump_json(),
     )
 
 

--- a/validator/background_loops.py
+++ b/validator/background_loops.py
@@ -10,7 +10,6 @@ import asyncio
 import logging
 import os
 import pathlib
-import traceback
 from collections.abc import Set
 from uuid import UUID
 
@@ -46,8 +45,7 @@ async def send_heartbeat_loop(session_id: UUID):
             )
             await asyncio.sleep(config.SEND_HEARTBEAT_INTERVAL_SECONDS)
     except Exception as e:
-        logger.error(f"Heartbeat failed after all retries, exiting: {type(e).__name__}: {e}")
-        logger.error(traceback.format_exc())
+        logger.error(f"Heartbeat failed after all retries, exiting: {type(e).__name__}: {e}", exc_info=True)
         os._exit(1)
 
 

--- a/validator/http_utils.py
+++ b/validator/http_utils.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import textwrap
 from typing import Any
 
 import httpx
@@ -16,10 +15,7 @@ HTTP_TIMEOUT_SECONDS = 120
 
 
 def _pretty_print_httpx_error(method: str, url: str, e: httpx.HTTPStatusError):
-    # HTTP error (4xx or 5xx)
-    logger.error(f"HTTP {e.response.status_code} {e.response.reason_phrase} during {method} {url}")
-
-    # Try and print the response as best as we can
+    # HTTP error (4xx or 5xx) — emit as a single log line to keep log entries intact
     try:
         response_json = e.response.json()
         if (
@@ -28,16 +24,15 @@ def _pretty_print_httpx_error(method: str, url: str, e: httpx.HTTPStatusError):
             and "detail" in response_json
             and isinstance(response_json["detail"], str)
         ):
-            # The response is a JSON that looks like {"detail": "..."}
-            logger.error(textwrap.indent(response_json["detail"], "  "))
+            detail = response_json["detail"]
         else:
-            # The response is a JSON
-            logger.error("Response (JSON):")
-            logger.error(textwrap.indent(json.dumps(response_json, indent=2), "  "))
+            detail = json.dumps(response_json)
     except Exception:
-        # The response is not a JSON
-        logger.error("Response:")
-        logger.error(textwrap.indent(e.response.text, "  "))
+        detail = e.response.text
+
+    logger.error(
+        f"HTTP {e.response.status_code} {e.response.reason_phrase} during {method} {url}: {detail}"
+    )
 
 
 def _platform_headers(bearer_token: str = None) -> dict | None:

--- a/validator/http_utils.py
+++ b/validator/http_utils.py
@@ -30,9 +30,7 @@ def _pretty_print_httpx_error(method: str, url: str, e: httpx.HTTPStatusError):
     except Exception:
         detail = e.response.text
 
-    logger.error(
-        f"HTTP {e.response.status_code} {e.response.reason_phrase} during {method} {url}: {detail}"
-    )
+    logger.error(f"HTTP {e.response.status_code} {e.response.reason_phrase} during {method} {url}: {detail}")
 
 
 def _platform_headers(bearer_token: str = None) -> dict | None:

--- a/validator/http_utils.py
+++ b/validator/http_utils.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import textwrap
 from typing import Any
 
 import httpx

--- a/validator/main.py
+++ b/validator/main.py
@@ -77,8 +77,7 @@ async def disconnect(reason: str):
         )
         logger.info("Disconnected validator")
     except Exception as e:
-        logger.error(f"Error in disconnect(): {type(e).__name__}: {e}")
-        logger.error(traceback.format_exc())
+        logger.error(f"Error in disconnect(): {type(e).__name__}: {e}", exc_info=True)
         os._exit(1)
 
 
@@ -392,9 +391,9 @@ async def _run_single_attempt(
 
     except Exception as e:
         logger.error(
-            f"Evaluation run {evaluation_run_id} for problem {problem_name} errored: {EvaluationRunErrorCode.VALIDATOR_INTERNAL_ERROR.get_error_message()}: {e}"
+            f"Evaluation run {evaluation_run_id} for problem {problem_name} errored: {EvaluationRunErrorCode.VALIDATOR_INTERNAL_ERROR.get_error_message()}: {e}",
+            exc_info=True,
         )
-        logger.error(traceback.format_exc())
 
         terminal_response = await update_evaluation_run(
             evaluation_run_id,
@@ -450,8 +449,7 @@ async def _run_evaluation_run(
         logger.info(f"Finished evaluation run {evaluation_run_id} for problem {problem_name}")
 
     except Exception as e:
-        logger.error(f"Error in _run_evaluation_run(): {type(e).__name__}: {e}")
-        logger.error(traceback.format_exc())
+        logger.error(f"Error in _run_evaluation_run(): {type(e).__name__}: {e}", exc_info=True)
         os._exit(1)
     finally:
         if task_digest:
@@ -901,7 +899,6 @@ if __name__ == "__main__":
         asyncio.run(disconnect("Keyboard interrupt"))
         os._exit(1)
     except Exception as e:
-        logger.error(f"Error in main(): {type(e).__name__}: {e}")
-        logger.error(traceback.format_exc())
+        logger.error(f"Error in main(): {type(e).__name__}: {e}", exc_info=True)
         asyncio.run(disconnect(f"Error in main(): {type(e).__name__}: {e}"))
         os._exit(1)


### PR DESCRIPTION
## Changes

- Remove `indent=2` from `model_dump_json()` calls so the JSON error payload stays on one line.
- Merge separate t`raceback.format_exc()` log calls into `exc_info=True` on the preceding error call.
- Consolidate `http_utils` multi-call HTTP error logging into one line.