### PR TITLE
Feat/restart validator machines

### DIFF
--- a/api/endpoints/admin.py
+++ b/api/endpoints/admin.py
@@ -7,8 +7,10 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, StringConstraints
 
 import api.config as config
+from api.endpoints import validator as validator_endpoint
 from models.banned_coldkey import BannedColdkey
 from queries.banned_coldkey import ban_coldkey, unban_coldkey
+from utils.debug_lock import DebugLock
 from utils.ttl import clear_all_ttl_caches
 
 router = APIRouter(tags=["admin"])
@@ -61,4 +63,26 @@ async def delete_banned_coldkey(miner_coldkey: str) -> Response:
     validate_coldkey(miner_coldkey)
     await unban_coldkey(miner_coldkey)
     clear_all_ttl_caches()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.delete(
+    "/validator-sessions/{validator_hotkey}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_coldkey_ban_admin)],
+)
+async def delete_validator_session(validator_hotkey: str) -> Response:
+    registration_lock = validator_endpoint.get_session_registration_lock(validator_hotkey)
+    async with DebugLock(registration_lock, f"delete_validator_session() for {validator_hotkey}"):
+        session_id = validator_endpoint.is_validator_registered(validator_hotkey)
+        validator = validator_endpoint.SESSION_ID_TO_VALIDATOR.get(session_id) if session_id else None
+        if validator is None:
+            raise HTTPException(status_code=404, detail="No connected validator with the given hotkey")
+
+        async with DebugLock(validator._lock, f"delete_validator_session() for {validator.name}'s lock"):
+            if validator.session_id in validator_endpoint.SESSION_ID_TO_VALIDATOR:
+                await validator_endpoint.delete_validator(
+                    validator, "The validator was kicked by an admin to force a restart."
+                )
+
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api/endpoints/admin.py
+++ b/api/endpoints/admin.py
@@ -8,8 +8,10 @@ from pydantic import BaseModel, StringConstraints
 
 import api.config as config
 from api.endpoints import validator as validator_endpoint
+from db.models import InternalFlagName
 from models.banned_coldkey import BannedColdkey
 from queries.banned_coldkey import ban_coldkey, unban_coldkey
+from queries.internal_flag import add_hotkey_to_blacklist, remove_hotkey_from_blacklist, set_internal_flag
 from utils.debug_lock import DebugLock
 from utils.ttl import clear_all_ttl_caches
 
@@ -86,3 +88,30 @@ async def delete_validator_session(validator_hotkey: str) -> Response:
                 )
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+class BlacklistedValidatorsResponse(BaseModel):
+    blacklisted_validators: list[str]
+
+
+class ValidatorsPausedResponse(BaseModel):
+    validators_paused: bool
+
+
+@router.put(
+    "/blacklisted-validators/{validator_hotkey}",
+    dependencies=[Depends(require_coldkey_ban_admin)],
+)
+async def put_blacklisted_validator(validator_hotkey: str) -> BlacklistedValidatorsResponse:
+    blacklist = await add_hotkey_to_blacklist(validator_hotkey)
+    return BlacklistedValidatorsResponse(blacklisted_validators=blacklist)
+
+
+@router.delete(
+    "/blacklisted-validators/{validator_hotkey}",
+    dependencies=[Depends(require_coldkey_ban_admin)],
+)
+async def delete_blacklisted_validator(validator_hotkey: str) -> BlacklistedValidatorsResponse:
+    blacklist = await remove_hotkey_from_blacklist(validator_hotkey)
+    return BlacklistedValidatorsResponse(blacklisted_validators=blacklist)
+

--- a/api/endpoints/admin.py
+++ b/api/endpoints/admin.py
@@ -115,3 +115,20 @@ async def delete_blacklisted_validator(validator_hotkey: str) -> BlacklistedVali
     blacklist = await remove_hotkey_from_blacklist(validator_hotkey)
     return BlacklistedValidatorsResponse(blacklisted_validators=blacklist)
 
+
+@router.put(
+    "/validators-paused",
+    dependencies=[Depends(require_coldkey_ban_admin)],
+)
+async def put_validators_paused() -> ValidatorsPausedResponse:
+    await set_internal_flag(InternalFlagName.VALIDATORS_PAUSED, "true")
+    return ValidatorsPausedResponse(validators_paused=True)
+
+
+@router.delete(
+    "/validators-paused",
+    dependencies=[Depends(require_coldkey_ban_admin)],
+)
+async def delete_validators_paused() -> ValidatorsPausedResponse:
+    await set_internal_flag(InternalFlagName.VALIDATORS_PAUSED, "false")
+    return ValidatorsPausedResponse(validators_paused=False)

--- a/queries/internal_flag.py
+++ b/queries/internal_flag.py
@@ -45,6 +45,64 @@ def _parse_flag_value(flag: InternalFlagName, raw: str | None) -> bool | list[st
         return raw
 
 
+# Advisory-lock namespace for internal-flag read-modify-write operations
+INTERNAL_FLAG_LOCK_NAMESPACE = -1730
+
+
+async def _lock_internal_flag(conn: DatabaseConnection, flag: InternalFlagName) -> None:
+    await conn.execute(
+        "SELECT pg_advisory_xact_lock($1, hashtext($2))",
+        INTERNAL_FLAG_LOCK_NAMESPACE,
+        flag.value,
+    )
+
+
+async def _upsert_internal_flag(conn: DatabaseConnection, flag: InternalFlagName, value: str) -> None:
+    await conn.execute(
+        """
+        INSERT INTO internal_flags (name, value, updated_at)
+        VALUES ($1, $2, NOW())
+        ON CONFLICT (name) DO UPDATE
+        SET value = EXCLUDED.value, updated_at = NOW()
+        """,
+        flag.value,
+        value,
+    )
+
+
+@db_operation
+async def set_internal_flag(conn: DatabaseConnection, flag: InternalFlagName, value: str) -> None:
+    async with conn.conn.transaction():
+        await _lock_internal_flag(conn, flag)
+        await _upsert_internal_flag(conn, flag, value)
+
+
+@db_operation
+async def add_hotkey_to_blacklist(conn: DatabaseConnection, hotkey: str) -> list[str]:
+    flag = InternalFlagName.BLACKLISTED_VALIDATORS
+    async with conn.conn.transaction():
+        await _lock_internal_flag(conn, flag)
+        raw = await conn.fetchval("SELECT value FROM internal_flags WHERE name = $1", flag.value)
+        blacklist = _parse_flag_value(flag, raw)
+        if hotkey not in blacklist:
+            blacklist.append(hotkey)
+            await _upsert_internal_flag(conn, flag, json.dumps(blacklist))
+    return blacklist
+
+
+@db_operation
+async def remove_hotkey_from_blacklist(conn: DatabaseConnection, hotkey: str) -> list[str]:
+    flag = InternalFlagName.BLACKLISTED_VALIDATORS
+    async with conn.conn.transaction():
+        await _lock_internal_flag(conn, flag)
+        raw = await conn.fetchval("SELECT value FROM internal_flags WHERE name = $1", flag.value)
+        blacklist = _parse_flag_value(flag, raw)
+        if hotkey in blacklist:
+            blacklist.remove(hotkey)
+            await _upsert_internal_flag(conn, flag, json.dumps(blacklist))
+    return blacklist
+
+
 @db_operation
 async def get_internal_flags_parsed(
     conn: DatabaseConnection, flags: list[InternalFlagName]

--- a/tests/api/test_admin_internal_flags.py
+++ b/tests/api/test_admin_internal_flags.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.config as config
+from api.endpoints import admin as admin_endpoint
+from api.endpoints.admin import router as admin_router
+
+
+def _fake_flag_queries(monkeypatch, blacklist: list[str]):
+    calls: list[tuple] = []
+
+    async def fake_add_hotkey_to_blacklist(hotkey: str) -> list[str]:
+        calls.append(("add", hotkey))
+        if hotkey not in blacklist:
+            blacklist.append(hotkey)
+        return blacklist
+
+    async def fake_remove_hotkey_from_blacklist(hotkey: str) -> list[str]:
+        calls.append(("remove", hotkey))
+        if hotkey in blacklist:
+            blacklist.remove(hotkey)
+        return blacklist
+
+    async def fake_set_internal_flag(flag, value: str) -> None:
+        calls.append(("set", flag, value))
+
+    monkeypatch.setattr(admin_endpoint, "add_hotkey_to_blacklist", fake_add_hotkey_to_blacklist)
+    monkeypatch.setattr(admin_endpoint, "remove_hotkey_from_blacklist", fake_remove_hotkey_from_blacklist)
+    monkeypatch.setattr(admin_endpoint, "set_internal_flag", fake_set_internal_flag)
+    return calls
+
+
+@pytest.mark.anyio
+async def test_put_blacklisted_validator_adds_hotkey(monkeypatch) -> None:
+    calls = _fake_flag_queries(monkeypatch, blacklist=["existing-hotkey"])
+
+    response = await admin_endpoint.put_blacklisted_validator("new-hotkey")
+
+    assert calls == [("add", "new-hotkey")]
+    assert response.blacklisted_validators == ["existing-hotkey", "new-hotkey"]
+
+
+@pytest.mark.anyio
+async def test_delete_blacklisted_validator_removes_hotkey(monkeypatch) -> None:
+    calls = _fake_flag_queries(monkeypatch, blacklist=["hotkey-a", "hotkey-b"])
+
+    response = await admin_endpoint.delete_blacklisted_validator("hotkey-a")
+
+    assert calls == [("remove", "hotkey-a")]
+    assert response.blacklisted_validators == ["hotkey-b"]
+
+
+@pytest.mark.anyio
+async def test_put_validators_paused_sets_flag_true(monkeypatch) -> None:
+    calls = _fake_flag_queries(monkeypatch, blacklist=[])
+
+    response = await admin_endpoint.put_validators_paused()
+
+    assert calls == [("set", admin_endpoint.InternalFlagName.VALIDATORS_PAUSED, "true")]
+    assert response.validators_paused is True
+
+
+@pytest.mark.anyio
+async def test_delete_validators_paused_sets_flag_false(monkeypatch) -> None:
+    calls = _fake_flag_queries(monkeypatch, blacklist=[])
+
+    response = await admin_endpoint.delete_validators_paused()
+
+    assert calls == [("set", admin_endpoint.InternalFlagName.VALIDATORS_PAUSED, "false")]
+    assert response.validators_paused is False
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(admin_router, prefix="/admin")
+    return app
+
+
+def test_flag_routes_require_admin_bearer_key(monkeypatch) -> None:
+    _fake_flag_queries(monkeypatch, blacklist=[])
+    client = TestClient(_make_app())
+    auth = {"Authorization": f"Bearer {config.COLDKEY_BAN_ADMIN_API_KEY}"}
+
+    routes = [
+        ("PUT", "/admin/blacklisted-validators/some-hotkey"),
+        ("DELETE", "/admin/blacklisted-validators/some-hotkey"),
+        ("PUT", "/admin/validators-paused"),
+        ("DELETE", "/admin/validators-paused"),
+    ]
+    for method, path in routes:
+        assert client.request(method, path).status_code == 401, (method, path)
+        assert client.request(method, path, headers=auth).status_code == 200, (method, path)

--- a/tests/api/test_admin_kick_validator.py
+++ b/tests/api/test_admin_kick_validator.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from uuid import uuid4
+from weakref import WeakValueDictionary
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+import api.config as config
+from api.endpoints import admin as admin_endpoint
+from api.endpoints import validator as validator_endpoint
+from api.endpoints.admin import router as admin_router
+
+
+def _make_validator(*, session_id, hotkey: str, ip_address: str = "127.0.0.1", evaluation_id=None):
+    return validator_endpoint.Validator(
+        session_id=session_id,
+        name="TAOApp",
+        hotkey=hotkey,
+        time_connected=datetime.now(timezone.utc),
+        ip_address=ip_address,
+        current_evaluation_id=evaluation_id,
+    )
+
+
+def _fake_cleanup(monkeypatch) -> list[tuple]:
+    cleanup_calls: list[tuple] = []
+
+    async def fake_update_unfinished_evaluation_runs_in_evaluation_id_to_errored(_evaluation_id, reason: str) -> None:
+        cleanup_calls.append(("mark_errored", _evaluation_id, reason))
+
+    async def fake_handle_evaluation_if_finished(_evaluation_id) -> None:
+        cleanup_calls.append(("handle_finished", _evaluation_id))
+
+    monkeypatch.setattr(
+        validator_endpoint,
+        "update_unfinished_evaluation_runs_in_evaluation_id_to_errored",
+        fake_update_unfinished_evaluation_runs_in_evaluation_id_to_errored,
+    )
+    monkeypatch.setattr(validator_endpoint, "handle_evaluation_if_finished", fake_handle_evaluation_if_finished)
+    return cleanup_calls
+
+
+@pytest.mark.anyio
+async def test_kick_removes_session_and_errors_active_evaluation(monkeypatch) -> None:
+    session_id = uuid4()
+    evaluation_id = uuid4()
+    validator = _make_validator(session_id=session_id, hotkey="validator-hotkey", evaluation_id=evaluation_id)
+    monkeypatch.setattr(validator_endpoint, "SESSION_ID_TO_VALIDATOR", {session_id: validator})
+    cleanup_calls = _fake_cleanup(monkeypatch)
+
+    response = await admin_endpoint.delete_validator_session("validator-hotkey")
+
+    assert response.status_code == 204
+    assert session_id not in validator_endpoint.SESSION_ID_TO_VALIDATOR
+    assert cleanup_calls == [
+        ("mark_errored", evaluation_id, "The validator was kicked by an admin to force a restart."),
+        ("handle_finished", evaluation_id),
+    ]
+

--- a/tests/api/test_admin_kick_validator.py
+++ b/tests/api/test_admin_kick_validator.py
@@ -61,3 +61,74 @@ async def test_kick_removes_session_and_errors_active_evaluation(monkeypatch) ->
         ("handle_finished", evaluation_id),
     ]
 
+
+@pytest.mark.anyio
+async def test_kick_validator_without_evaluation_removes_session(monkeypatch) -> None:
+    session_id = uuid4()
+    validator = _make_validator(session_id=session_id, hotkey="validator-hotkey")
+    monkeypatch.setattr(validator_endpoint, "SESSION_ID_TO_VALIDATOR", {session_id: validator})
+    cleanup_calls = _fake_cleanup(monkeypatch)
+
+    response = await admin_endpoint.delete_validator_session("validator-hotkey")
+
+    assert response.status_code == 204
+    assert validator_endpoint.SESSION_ID_TO_VALIDATOR == {}
+    assert cleanup_calls == []
+
+
+@pytest.mark.anyio
+async def test_kick_waits_for_in_flight_registration(monkeypatch) -> None:
+    monkeypatch.setattr(validator_endpoint, "SESSION_REGISTRATION_LOCKS", WeakValueDictionary())
+    session_id = uuid4()
+    validator = _make_validator(session_id=session_id, hotkey="validator-hotkey")
+    monkeypatch.setattr(validator_endpoint, "SESSION_ID_TO_VALIDATOR", {session_id: validator})
+    _fake_cleanup(monkeypatch)
+
+    registration_lock = validator_endpoint.get_session_registration_lock("validator-hotkey")
+    async with registration_lock:
+        kick_task = asyncio.create_task(admin_endpoint.delete_validator_session("validator-hotkey"))
+        await asyncio.sleep(0.05)
+        assert not kick_task.done()
+
+    response = await asyncio.wait_for(kick_task, timeout=1)
+    assert response.status_code == 204
+    assert session_id not in validator_endpoint.SESSION_ID_TO_VALIDATOR
+
+
+@pytest.mark.anyio
+async def test_kick_unknown_hotkey_returns_404(monkeypatch) -> None:
+    monkeypatch.setattr(validator_endpoint, "SESSION_ID_TO_VALIDATOR", {})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await admin_endpoint.delete_validator_session("missing-hotkey")
+
+    assert exc_info.value.status_code == 404
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(admin_router, prefix="/admin")
+    return app
+
+
+def test_kick_route_requires_admin_bearer_key(monkeypatch) -> None:
+    session_id = uuid4()
+    validator = _make_validator(session_id=session_id, hotkey="validator-hotkey")
+    monkeypatch.setattr(validator_endpoint, "SESSION_ID_TO_VALIDATOR", {session_id: validator})
+    _fake_cleanup(monkeypatch)
+    client = TestClient(_make_app())
+
+    assert client.delete("/admin/validator-sessions/validator-hotkey").status_code == 401
+    assert (
+        client.delete(
+            "/admin/validator-sessions/validator-hotkey",
+            headers={"Authorization": "Bearer wrong-key"},
+        ).status_code
+        == 401
+    )
+    response = client.delete(
+        "/admin/validator-sessions/validator-hotkey",
+        headers={"Authorization": f"Bearer {config.COLDKEY_BAN_ADMIN_API_KEY}"},
+    )
+    assert response.status_code == 204
+    assert session_id not in validator_endpoint.SESSION_ID_TO_VALIDATOR

--- a/tests/queries/test_internal_flag.py
+++ b/tests/queries/test_internal_flag.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import utils.database as _db
+from db.models.internal_flag import InternalFlagName
+from queries.internal_flag import (
+    add_hotkey_to_blacklist,
+    get_internal_flags_parsed,
+    remove_hotkey_from_blacklist,
+    set_internal_flag,
+)
+
+
+@pytest.fixture(autouse=True)
+async def clean_tables(postgres_db):
+    async with _db.pool.acquire() as conn:
+        await conn.execute("TRUNCATE internal_flags")
+    yield
+    async with _db.pool.acquire() as conn:
+        await conn.execute("TRUNCATE internal_flags")
+
+
+@pytest.mark.anyio
+async def test_set_internal_flag_inserts_then_updates() -> None:
+    await set_internal_flag(InternalFlagName.VALIDATORS_PAUSED, "true")
+    flags = await get_internal_flags_parsed([InternalFlagName.VALIDATORS_PAUSED])
+    assert flags[InternalFlagName.VALIDATORS_PAUSED] is True
+
+    await set_internal_flag(InternalFlagName.VALIDATORS_PAUSED, "false")
+    flags = await get_internal_flags_parsed([InternalFlagName.VALIDATORS_PAUSED])
+    assert flags[InternalFlagName.VALIDATORS_PAUSED] is False
+
+
+@pytest.mark.anyio
+async def test_blacklist_add_and_remove_roundtrip() -> None:
+    assert await add_hotkey_to_blacklist("hotkey-a") == ["hotkey-a"]
+    assert await add_hotkey_to_blacklist("hotkey-b") == ["hotkey-a", "hotkey-b"]
+    # Idempotent add
+    assert await add_hotkey_to_blacklist("hotkey-a") == ["hotkey-a", "hotkey-b"]
+
+    flags = await get_internal_flags_parsed([InternalFlagName.BLACKLISTED_VALIDATORS])
+    assert flags[InternalFlagName.BLACKLISTED_VALIDATORS] == ["hotkey-a", "hotkey-b"]
+
+    assert await remove_hotkey_from_blacklist("hotkey-a") == ["hotkey-b"]
+    # Idempotent remove
+    assert await remove_hotkey_from_blacklist("missing") == ["hotkey-b"]
+
+
+@pytest.mark.anyio
+async def test_add_to_blacklist_starts_from_empty_when_flag_row_missing() -> None:
+    assert await add_hotkey_to_blacklist("first-hotkey") == ["first-hotkey"]
+
+
+@pytest.mark.anyio
+async def test_concurrent_blacklist_adds_do_not_lose_updates() -> None:
+    hotkeys = [f"hotkey-{i}" for i in range(8)]
+    await asyncio.gather(*(add_hotkey_to_blacklist(hotkey) for hotkey in hotkeys))
+
+    flags = await get_internal_flags_parsed([InternalFlagName.BLACKLISTED_VALIDATORS])
+    assert sorted(flags[InternalFlagName.BLACKLISTED_VALIDATORS]) == sorted(hotkeys)


### PR DESCRIPTION
Adds admin endpoints (protected w admin auth)

- `DELETE /admin/validator-sessions/{hotkey}` - restart a validator/screener
- `PUT /admin/blacklisted-validators/{hotkey}` - pause a vali 
- `DELETE /admin/blacklisted-validators/{hotkey}` - unpause a vali
- `PUT /admin/validators-paused` - pause all validators/screeners
- `DELETE /admin/validators-paused` - unpause all validators/screeners