### PR TITLE
Hotfix/short circuit early

### DIFF
--- a/execution/artifacts.py
+++ b/execution/artifacts.py
@@ -7,6 +7,7 @@ Entry point is 'result_from_summary'.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 from xml.etree import ElementTree
@@ -25,6 +26,8 @@ from execution.types import ExecutionResult, FailureContext, TrialSnapshot
 from models.problem import ProblemTestCategory, ProblemTestResult, ProblemTestResultStatus
 from ridges_harbor._stdlib_contract import AGENT_LOG_FILENAMES, HARBOR_RUNNER_ERROR_FILENAME
 from ridges_harbor.runner import HarborRunSummary
+
+logger = logging.getLogger(__name__)
 
 
 class VerifierTestResultsPayload(BaseModel):
@@ -54,8 +57,15 @@ def result_from_summary(summary: HarborRunSummary) -> ExecutionResult:
 
     trial_exception = summary.trial_result.exception_info
     if trial_exception is not None:
-        if _agent_timed_out_then_verifier_produced_reward(summary):
-            return parse_execution_artifacts(summary, trial_paths=trial_paths, context=context)
+        if _agent_timed_out_then_verifier_produced_reward(summary, trial_paths=trial_paths):
+            try:
+                return parse_execution_artifacts(summary, trial_paths=trial_paths, context=context)
+            except Exception as exception:
+                logger.warning(
+                    f"Partial-credit scoring of a timed-out trial failed; "
+                    f"falling back to the recorded trial exception: {exception}",
+                    exc_info=True,
+                )
 
         failure = classify_trial_failure(
             trial_result=summary.trial_result,
@@ -72,12 +82,18 @@ def result_from_summary(summary: HarborRunSummary) -> ExecutionResult:
     return parse_execution_artifacts(summary, trial_paths=trial_paths, context=context)
 
 
-def _agent_timed_out_then_verifier_produced_reward(summary: HarborRunSummary) -> bool:
+def _agent_timed_out_then_verifier_produced_reward(summary: HarborRunSummary, *, trial_paths: TrialPaths) -> bool:
     """True when Harbor recorded an agent timeout, then completed verification
-    with a usable numeric reward.
+    with a usable numeric reward on a patch the agent managed to export.
+
+    Without a patch artifact there is nothing to score: the timeout killed the
+    runtime before it exported patch.diff, so the timeout stays the failure.
     """
     exception_type = (summary.trial_result.exception_info.exception_type or "").strip()
     if exception_type not in AGENT_TIMEOUT_EXCEPTION_NAMES:
+        return False
+
+    if not read_text(trial_paths.agent_dir / "patch.diff"):
         return False
 
     verifier_result = summary.trial_result.verifier_result

--- a/tests/execution/test_artifacts.py
+++ b/tests/execution/test_artifacts.py
@@ -216,6 +216,66 @@ def test_zero_verifier_reward_after_agent_timeout_records_finished_zero(tmp_path
     assert result.verifier_reward == 0.0
 
 
+def test_agent_timeout_without_patch_classifies_as_agent_timeout(tmp_path: Path) -> None:
+    """A timed-out agent that never exported patch.diff is the agent's fault, not a validator error."""
+    summary = make_summary(
+        tmp_path,
+        exception_info={
+            "exception_type": "AgentTimeoutError",
+            "exception_message": "Agent execution timed out after 600.0 seconds",
+            "exception_traceback": "Traceback...\n_execute_agent\n",
+        },
+        patch=None,
+        eval_log="verifier output",
+        verifier_result={"rewards": {"reward": 0.0}},
+    )
+
+    with pytest.raises(EvaluationRunException) as exc_info:
+        result_from_summary(summary)
+
+    assert exc_info.value.error_code == EvaluationRunErrorCode.AGENT_TIMEOUT_RUNNING_AGENT
+
+
+def test_agent_timeout_with_empty_patch_classifies_as_agent_timeout(tmp_path: Path) -> None:
+    """An empty patch.diff is as unscoreable as a missing one."""
+    summary = make_summary(
+        tmp_path,
+        exception_info={
+            "exception_type": "AgentTimeoutError",
+            "exception_message": "Agent execution timed out after 600.0 seconds",
+            "exception_traceback": "Traceback...\n_execute_agent\n",
+        },
+        patch="",
+        eval_log="verifier output",
+        verifier_result={"rewards": {"reward": 0.0}},
+    )
+
+    with pytest.raises(EvaluationRunException) as exc_info:
+        result_from_summary(summary)
+
+    assert exc_info.value.error_code == EvaluationRunErrorCode.AGENT_TIMEOUT_RUNNING_AGENT
+
+
+def test_agent_timeout_with_unparseable_artifacts_falls_back_to_agent_timeout(tmp_path: Path) -> None:
+    """When partial-credit scoring of a timed-out run fails, keep the agent-timeout classification."""
+    summary = make_summary(
+        tmp_path,
+        exception_info={
+            "exception_type": "AgentTimeoutError",
+            "exception_message": "Agent execution timed out after 600.0 seconds",
+            "exception_traceback": "Traceback...\n_execute_agent\n",
+        },
+        test_results={"success": True, "output": "not-a-list"},
+        eval_log="verifier output",
+        verifier_result={"rewards": {"reward": 0.0}},
+    )
+
+    with pytest.raises(EvaluationRunException) as exc_info:
+        result_from_summary(summary)
+
+    assert exc_info.value.error_code == EvaluationRunErrorCode.AGENT_TIMEOUT_RUNNING_AGENT
+
+
 def test_non_timeout_exception_with_verified_reward_still_errors(tmp_path: Path) -> None:
     """Only agent timeouts defer to the verifier; other exceptions keep the error path."""
     summary = make_summary(


### PR DESCRIPTION
Short-circuits cases when there is no diff/exported patch when agent times out to 1020 instead of 2000 to exit early. 