### PR TITLE
Restrict agent-phase DNS egress to cluster DNS

### DIFF
--- a/k8s/local/network-policies.yaml
+++ b/k8s/local/network-policies.yaml
@@ -1,5 +1,5 @@
 ---
-# Agent phase: allow only DNS + outbound port 443.
+# Agent phase: allow only cluster DNS + outbound port 443.
 # All HTTPS traffic from the main container is transparently intercepted by the
 # iptables REDIRECT rule and forwarded to the proxy SNI router on port 15443.
 # The proxy sidecar (UID 1337, exempt from REDIRECT) reaches the internet directly.
@@ -16,8 +16,15 @@ spec:
   policyTypes:
     - Egress
   egress:
-    # DNS resolution
-    - ports:
+    # DNS resolution — cluster DNS only (kube-dns / CoreDNS in kube-system).
+    # Without a `to:` selector port 53 is open to the entire internet, which
+    # would let agent code exfiltrate data or tunnel arbitrary traffic (e.g.
+    # LLM calls to non-whitelisted providers) over DNS queries.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
         - port: 53
           protocol: UDP
         - port: 53


### PR DESCRIPTION
## What

- scope the `ridges-agent-egress` DNS rule to cluster DNS (`kube-system` namespace selector) instead of leaving UDP/TCP 53 open to `0.0.0.0/0`
- update the policy header comment accordingly

## Why

During the agent phase, port 443 egress is transparently intercepted (iptables REDIRECT) and gated by the proxy's SNI allowlist — but port 53 was open to the entire internet. Agent code could query arbitrary authoritative DNS servers, which is a working DNS-tunneling channel out of the sandbox: low bandwidth, but sufficient to exfiltrate data or relay traffic to non-whitelisted endpoints, bypassing the SNI allowlist entirely.

Scoping DNS egress to `kube-system` (kube-dns / CoreDNS, and node-local-dns DaemonSets where present) closes this gap while leaving legitimate resolution untouched — agent pods resolve through the cluster resolver anyway. The HTTPS interception path is unchanged.

## Validation

- manifest parses (7 YAML documents), `git diff --check` clean
- not yet applied against a live kind cluster — worth a quick `k8s/local` smoke run to confirm CoreDNS resolution still works for agent pods

## Related

While you're in the sandbox/networking corner — I'd appreciate a look at #469 (adds `deepseek-ai/DeepSeek-V4-Flash-0731` to the OpenRouter whitelist; minimal, fully unit-tested, no paid inference calls) and #470 (Gonka provider for Kimi K2.6; larger, operator-controlled broker design). #469 in particular is a small low-risk addition that would immediately let miners evaluate against the new DeepSeek V4 Flash.