### PR TITLE
Update/pipeline stats update

### DIFF
--- a/api/endpoints/agent.py
+++ b/api/endpoints/agent.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, HTTPException
 
-from models.agent import Agent
+from models.agent import PublicAgent
 from queries.agent import get_agent_by_evaluation_run_id
 
 router = APIRouter()
@@ -10,7 +10,7 @@ router = APIRouter()
 
 # /agent/get-by-evaluation-run-id?evaluation_run_id=
 @router.get("/get-by-evaluation-run-id")
-async def agent_get_by_evaluation_run_id(evaluation_run_id: UUID) -> Agent:
+async def agent_get_by_evaluation_run_id(evaluation_run_id: UUID) -> PublicAgent:
     agent = await get_agent_by_evaluation_run_id(evaluation_run_id)
 
     if agent is None:

--- a/api/endpoints/evaluation_sets.py
+++ b/api/endpoints/evaluation_sets.py
@@ -6,14 +6,13 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from api.config import EARLIEST_SET_ID_WITH_GOOD_DATA
 from api.incentives import CurrentAllocations, get_current_allocations, get_subnet_hotkey_info
+from models.agent import AgentStatus, PublicAgent
 from models.evaluation_set import (
-    ApprovedAgent,
     EvaluationSet,
     EvaluationSetDetail,
     EvaluationSetDetailBenchmarkThreshold,
     EvaluationSetDetailEfficiency,
     EvaluationSetDetailEfficiencyAgent,
-    EvaluationSetDetailLeaderboardAgent,
     EvaluationSetDetailPipelineStage,
     EvaluationSetDetailScores,
     EvaluationSetDetailSubmissions,
@@ -321,9 +320,9 @@ async def evaluation_set_overview(
 #
 # GET evaluation-sets/{set_id}/leaderboard
 #
-async def _build_leaderboard(set_id: int) -> list[EvaluationSetDetailLeaderboardAgent]:
+async def _build_leaderboard(set_id: int) -> list[PublicAgent]:
     agent_rows = await get_evaluation_set_leaderboard_agents(set_id)
-    return [EvaluationSetDetailLeaderboardAgent(**dict(row), set_id=set_id) for row in agent_rows]
+    return [PublicAgent(**dict(row), set_id=set_id) for row in agent_rows]
 
 
 _cached_build_leaderboard = ttl_cache(ttl_seconds=CACHE_PAST_SET_DATA_TTL_SECONDS)(_build_leaderboard)
@@ -332,7 +331,7 @@ _cached_build_leaderboard = ttl_cache(ttl_seconds=CACHE_PAST_SET_DATA_TTL_SECOND
 @router.get("/{set_id}/leaderboard")
 async def evaluation_set_leaderboard(
     set_id: Annotated[int, Depends(resolve_set_id)],
-) -> list[EvaluationSetDetailLeaderboardAgent]:
+) -> list[PublicAgent]:
     latest = await _get_latest_set_id()
     if set_id != latest:
         return await _cached_build_leaderboard(set_id)
@@ -346,31 +345,14 @@ async def evaluation_set_leaderboard(
 
 async def _build_approved_agents(
     set_id: int,
-) -> list[ApprovedAgent]:
+) -> list[PublicAgent]:
     agent_rows = await get_approved_agents_for_set(set_id)
-
     return [
-        ApprovedAgent(
-            id=row["agent_id"],
-            miner_hotkey=row["miner_hotkey"],
-            name=row["name"],
-            version_num=row["version_num"],
-            created_at=row["created_at"],
-            final_score=row["final_score"],
-            emission=None,
-            reward_weight=None,
-            approved_at=row["approved_at"],
-            approval_review_status=row["approval_review_status"],
-            performance_delta=row["performance_delta"],
-            cost_delta=row["cost_delta"],
-            relative_improvement_units=row["relative_improvement_units"],
-            time_multiplier=row["time_multiplier"],
-            initial_reward_score=row["initial_reward_score"],
-            baseline_agent_id=row["baseline_agent_id"],
-            baseline_agent_name=row["baseline_agent_name"],
-            baseline_agent_version_num=row["baseline_agent_version_num"],
-            average_runtime_seconds=row["average_runtime_seconds"],
-            average_cost_usd=row["average_cost_usd"],
+        PublicAgent(
+            **dict(row),
+            status=AgentStatus.finished,
+            set_id=set_id,
+            approved=True,
         )
         for row in agent_rows
     ]
@@ -380,9 +362,9 @@ _cached_build_approved_agents = ttl_cache(ttl_seconds=CACHE_PAST_SET_DATA_TTL_SE
 
 
 async def _add_onchain_approved_agent_data(
-    agents: list[ApprovedAgent],
+    agents: list[PublicAgent],
     allocations: CurrentAllocations | None,
-) -> list[ApprovedAgent]:
+) -> list[PublicAgent]:
     if not agents:
         return []
 
@@ -400,7 +382,7 @@ async def _add_onchain_approved_agent_data(
             agent.model_copy(
                 update={
                     "emission": None if hotkey_info is None else hotkey_info.emission,
-                    "reward_weight": None if reward_weights is None else reward_weights.get(agent.id, 0.0),
+                    "reward_weight": None if reward_weights is None else reward_weights.get(agent.agent_id, 0.0),
                 }
             )
         )
@@ -416,7 +398,7 @@ async def _safe_current_allocations() -> CurrentAllocations | None:
 
 
 @router.get("/{set_id}/approved-agents")
-async def evaluation_set_approved_agents(set_id: Annotated[int, Depends(resolve_set_id)]) -> list[ApprovedAgent]:
+async def evaluation_set_approved_agents(set_id: Annotated[int, Depends(resolve_set_id)]) -> list[PublicAgent]:
     latest = await _get_latest_set_id()
     if set_id != latest:
         agents = await _cached_build_approved_agents(set_id)

--- a/api/endpoints/evaluation_sets.py
+++ b/api/endpoints/evaluation_sets.py
@@ -136,6 +136,11 @@ async def _build_detail(set_id: int) -> EvaluationSetDetail:
 
     pipeline = [
         EvaluationSetDetailPipelineStage(
+            stage="total",
+            count=total,
+            pass_rate=_pass_rate(total, total),
+        ),
+        EvaluationSetDetailPipelineStage(
             stage="pre_screening",
             count=pre_screening_count,
             pass_rate=_pass_rate(pre_screening_count, total),

--- a/api/endpoints/retrieval.py
+++ b/api/endpoints/retrieval.py
@@ -18,7 +18,6 @@ from queries.agent import (
     get_agent_score_and_set_id,
     get_agents_in_queue,
     get_all_public_agents_by_miner_hotkey,
-    get_benchmark_agents,
     get_code_hiding_score_cutoff,
     get_latest_public_agent_for_miner_hotkey,
     get_public_agent_by_id,
@@ -56,13 +55,6 @@ async def queue(stage: QueueStage) -> List[PublicAgent]:
 @ttl_cache(ttl_seconds=60)  # 1 minute
 async def top_agents() -> List[PublicAgent]:
     return await get_top_agents(number_of_agents=50)
-
-
-# /retrieval/benchmark-agents
-@router.get("/benchmark-agents")
-@ttl_cache(ttl_seconds=10 * 60)  # 10 minutes
-async def benchmark_agents() -> List[PublicAgent]:
-    return await get_benchmark_agents()
 
 
 # /retrieval/agent-by-id?agent_id=

--- a/api/endpoints/retrieval.py
+++ b/api/endpoints/retrieval.py
@@ -7,18 +7,21 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 import api.config as config
-from models.agent import Agent, AgentScored, AgentStatus, BenchmarkAgentScored, PossiblyBenchmarkAgent
+from models.agent import (
+    AgentStatus,
+    PublicAgent,
+)
 from models.evaluation import Evaluation, EvaluationWithRuns
 from models.queue import QueueStage
 from queries.agent import (
     get_agent_by_id,
     get_agent_score_and_set_id,
     get_agents_in_queue,
-    get_all_agents_by_miner_hotkey,
+    get_all_public_agents_by_miner_hotkey,
     get_benchmark_agents,
     get_code_hiding_score_cutoff,
-    get_latest_agent_for_miner_hotkey,
-    get_possibly_benchmark_agent_by_id,
+    get_latest_public_agent_for_miner_hotkey,
+    get_public_agent_by_id,
     get_top_agents,
 )
 from queries.evaluation import get_approved_leader_ranking_for_set, get_evaluations_for_agent_id
@@ -43,28 +46,29 @@ router = APIRouter()
 # /retrieval/queue?stage={pre_screening|screener_1|screener_2|validator}
 @router.get("/queue")
 @ttl_cache(ttl_seconds=60)  # 1 minute
-async def queue(stage: QueueStage) -> List[Agent]:
-    return await get_agents_in_queue(stage)
+async def queue(stage: QueueStage) -> List[PublicAgent]:
+    agents = await get_agents_in_queue(stage)
+    return [PublicAgent(**agent.model_dump()) for agent in agents]
 
 
 # /retrieval/top-agents
 @router.get("/top-agents")
 @ttl_cache(ttl_seconds=60)  # 1 minute
-async def top_agents() -> List[AgentScored]:
+async def top_agents() -> List[PublicAgent]:
     return await get_top_agents(number_of_agents=50)
 
 
 # /retrieval/benchmark-agents
 @router.get("/benchmark-agents")
 @ttl_cache(ttl_seconds=10 * 60)  # 10 minutes
-async def benchmark_agents() -> List[BenchmarkAgentScored]:
+async def benchmark_agents() -> List[PublicAgent]:
     return await get_benchmark_agents()
 
 
 # /retrieval/agent-by-id?agent_id=
 @router.get("/agent-by-id")
-async def agent_by_id(agent_id: UUID) -> PossiblyBenchmarkAgent:
-    agent = await get_possibly_benchmark_agent_by_id(agent_id)
+async def agent_by_id(agent_id: UUID) -> PublicAgent:
+    agent = await get_public_agent_by_id(agent_id)
 
     if agent is None:
         raise HTTPException(status_code=404, detail=f"Agent with ID {agent_id} not found")
@@ -74,8 +78,8 @@ async def agent_by_id(agent_id: UUID) -> PossiblyBenchmarkAgent:
 
 # /retrieval/agent-by-hotkey?miner_hotkey=
 @router.get("/agent-by-hotkey")
-async def agent_by_hotkey(miner_hotkey: str) -> Agent:
-    agent = await get_latest_agent_for_miner_hotkey(miner_hotkey=miner_hotkey)
+async def agent_by_hotkey(miner_hotkey: str) -> PublicAgent:
+    agent = await get_latest_public_agent_for_miner_hotkey(miner_hotkey=miner_hotkey)
 
     if agent is None:
         raise HTTPException(status_code=404, detail=f"Agent with miner hotkey {miner_hotkey} not found")
@@ -85,8 +89,8 @@ async def agent_by_hotkey(miner_hotkey: str) -> Agent:
 
 # /retrieval/all-agents-by-hotkey?miner_hotkey=
 @router.get("/all-agents-by-hotkey")
-async def all_agents_by_hotkey(miner_hotkey: str) -> List[Agent]:
-    agents = await get_all_agents_by_miner_hotkey(miner_hotkey=miner_hotkey)
+async def all_agents_by_hotkey(miner_hotkey: str) -> List[PublicAgent]:
+    agents = await get_all_public_agents_by_miner_hotkey(miner_hotkey=miner_hotkey)
     return agents
 
 

--- a/api/endpoints/validator.py
+++ b/api/endpoints/validator.py
@@ -39,7 +39,7 @@ from api.endpoints.validator_models import (
     ValidatorUpdateEvaluationRunResponse,
 )
 from db.models import InternalFlagName
-from models.agent import Agent, AgentStatus
+from models.agent import Agent, AgentStatus, PublicAgent
 from models.evaluation import Evaluation, EvaluationStatus
 from models.evaluation_run import (
     EvaluationRun,
@@ -1213,7 +1213,7 @@ async def validator_connected_validators_info() -> List[ConnectedValidatorInfo]:
 
         if validator.current_evaluation_id is not None:
             connected_validator.evaluation = validator.current_evaluation
-            connected_validator.agent = validator.current_agent
+            connected_validator.agent = PublicAgent(**validator.current_agent.model_dump())
 
         connected_validators.append(connected_validator)
 
@@ -1243,7 +1243,11 @@ async def handle_evaluation_if_finished(evaluation_id: UUID) -> None:
 
             case AgentStatus.screening_2:
                 top_agents = await get_top_agents(number_of_agents=1)
-                top_score = top_agents[0].final_score if top_agents else 0
+                top_score = (
+                    top_agents[0].competition_state.final_score
+                    if top_agents and top_agents[0].competition_state is not None
+                    else 0
+                )
                 pruning_threshold_score = top_score * config.PRUNE_THRESHOLD
 
                 if hydrated_evaluation.score >= max(config.SCREENER_2_THRESHOLD, pruning_threshold_score):

--- a/models/agent.py
+++ b/models/agent.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from enum import Enum
-from typing import Optional
+from typing import Any, Mapping, Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, computed_field, model_validator
 
 
 class AgentStatus(str, Enum):
@@ -27,6 +27,166 @@ class ApprovalReviewStatus(str, Enum):
     rejected = "rejected"
 
 
+class AgentCompetitionStatus(str, Enum):
+    """Public agent status from the point of view of a competition"""
+
+    pre_screening = "pre_screening"
+    failed_pre_screening = "failed_pre_screening"
+    pre_screening_needs_review = "pre_screening_needs_review"
+    screening_1 = "screening_1"
+    failed_screening_1 = "failed_screening_1"
+    screening_2 = "screening_2"
+    failed_screening_2 = "failed_screening_2"
+    evaluating = "evaluating"
+    finished = "finished"
+    cancelled = "cancelled"
+    rejected = "rejected"
+    didnt_qualify = "didnt_qualify"
+    under_review = "under_review"
+    approved = "approved"
+    baseline = "baseline"
+
+
+def derive_agent_competition_status(
+    *,
+    status: AgentStatus | str,
+    set_id: int | None = None,
+    approved: bool | None = None,
+    approval_review_status: ApprovalReviewStatus | str | None = None,
+    performance_delta: float | None = None,
+    cost_delta: float | None = None,
+    relative_improvement_units: float | None = None,
+    approved_at: datetime | None = None,
+    baseline_agent_id: UUID | None = None,
+) -> AgentCompetitionStatus:
+    """Derive the single public competition status for an agent.
+
+    A rejection invalidates an existing approval. Other in-progress review
+    states do not revoke a published approval, so an approved agent remains
+    approved while a later review is pending. Without any competition context,
+    a raw ``finished`` status is preserved instead of guessing that the agent
+    failed to qualify.
+    """
+
+    if isinstance(status, str):
+        status = AgentStatus(status)
+    if isinstance(approval_review_status, str):
+        approval_review_status = ApprovalReviewStatus(approval_review_status)
+
+    if status is not AgentStatus.finished:
+        return AgentCompetitionStatus(status.value)
+
+    if approval_review_status is ApprovalReviewStatus.rejected:
+        return AgentCompetitionStatus.rejected
+
+    is_approved = approved is True or approval_review_status is ApprovalReviewStatus.approved
+    if is_approved:
+        if performance_delta is None and cost_delta is None and relative_improvement_units is not None:
+            return AgentCompetitionStatus.baseline
+        return AgentCompetitionStatus.approved
+
+    if approval_review_status in {
+        ApprovalReviewStatus.pending,
+        ApprovalReviewStatus.processing,
+        ApprovalReviewStatus.under_review,
+    }:
+        return AgentCompetitionStatus.under_review
+
+    has_competition_context = (set_id is not None and approved is not None) or any(
+        value is not None
+        for value in (
+            approval_review_status,
+            approved_at,
+            performance_delta,
+            cost_delta,
+            relative_improvement_units,
+            baseline_agent_id,
+        )
+    )
+    return AgentCompetitionStatus.didnt_qualify if has_competition_context else AgentCompetitionStatus.finished
+
+
+class AgentCompetitionState(BaseModel):
+    set_id: int
+    status: AgentCompetitionStatus
+    approved: bool
+    approval_review_status: ApprovalReviewStatus | None = None
+    rank: int | None = None
+    final_score: float | None = None
+    validator_count: int | None = None
+    validator_hotkeys: list[str] | None = None
+    average_cost_usd: float | None = None
+    average_runtime_seconds: float | None = None
+    disqualified: bool | None = None
+    approved_at: datetime | None = None
+    performance_delta: float | None = None
+    cost_delta: float | None = None
+    relative_improvement_units: float | None = None
+    time_multiplier: float | None = None
+    initial_reward_score: float | None = None
+    baseline_agent_id: UUID | None = None
+    baseline_agent_name: str | None = None
+    baseline_agent_version_num: int | None = None
+
+
+def build_agent_competition_state(
+    *,
+    status: AgentStatus | str,
+    set_id: int,
+    approved: bool,
+    approval_review_status: ApprovalReviewStatus | str | None = None,
+    rank: int | None = None,
+    final_score: float | None = None,
+    validator_count: int | None = None,
+    validator_hotkeys: list[str] | None = None,
+    average_cost_usd: float | None = None,
+    average_runtime_seconds: float | None = None,
+    disqualified: bool | None = None,
+    approved_at: datetime | None = None,
+    performance_delta: float | None = None,
+    cost_delta: float | None = None,
+    relative_improvement_units: float | None = None,
+    time_multiplier: float | None = None,
+    initial_reward_score: float | None = None,
+    baseline_agent_id: UUID | None = None,
+    baseline_agent_name: str | None = None,
+    baseline_agent_version_num: int | None = None,
+) -> AgentCompetitionState:
+    competition_status = derive_agent_competition_status(
+        status=status,
+        set_id=set_id,
+        approved=approved,
+        approval_review_status=approval_review_status,
+        performance_delta=performance_delta,
+        cost_delta=cost_delta,
+        relative_improvement_units=relative_improvement_units,
+        approved_at=approved_at,
+        baseline_agent_id=baseline_agent_id,
+    )
+    return AgentCompetitionState(
+        set_id=set_id,
+        status=competition_status,
+        approved=competition_status in {AgentCompetitionStatus.approved, AgentCompetitionStatus.baseline},
+        approval_review_status=approval_review_status,
+        rank=rank,
+        final_score=final_score,
+        validator_count=validator_count,
+        validator_hotkeys=validator_hotkeys,
+        average_cost_usd=average_cost_usd,
+        average_runtime_seconds=average_runtime_seconds,
+        disqualified=disqualified,
+        approved_at=approved_at,
+        performance_delta=performance_delta,
+        cost_delta=cost_delta,
+        relative_improvement_units=relative_improvement_units,
+        time_multiplier=time_multiplier,
+        initial_reward_score=initial_reward_score,
+        baseline_agent_id=baseline_agent_id,
+        baseline_agent_name=baseline_agent_name,
+        baseline_agent_version_num=baseline_agent_version_num,
+    )
+
+
 class AgentBase(BaseModel):
     miner_hotkey: str
 
@@ -40,8 +200,167 @@ class AgentBase(BaseModel):
 
 
 class Agent(AgentBase):
+    """Core pipeline agent used by evaluation, queue, and upload machinery."""
+
     agent_id: UUID
     approval_review_status: ApprovalReviewStatus | None = None
+
+
+class PublicAgent(BaseModel):
+    """The single agent shape returned by frontend-facing endpoints.
+
+    Pipeline code continues to use Agent model. Public fields that are not
+    available in a particular view are included as null.
+    """
+
+    agent_id: UUID
+    miner_hotkey: str
+    name: str
+    version_num: int
+    status: AgentStatus
+    created_at: datetime
+    is_benchmark_agent: bool = False
+    benchmark_description: str | None = None
+    emission: float | None = None
+    reward_weight: float | None = None
+    competition_state: AgentCompetitionState | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_public_agent(cls, data: Any) -> Any:
+        if not isinstance(data, Mapping):
+            return data
+
+        values = dict(data)
+        if "agent_id" not in values and "id" in values:
+            values["agent_id"] = values.pop("id")
+
+        set_id = values.get("set_id")
+        if set_id is not None:
+            values["competition_state"] = build_agent_competition_state(
+                status=values["status"],
+                set_id=set_id,
+                approved=values.get("approved") is True,
+                approval_review_status=values.get("approval_review_status"),
+                rank=values.get("rank"),
+                final_score=values.get("final_score"),
+                validator_count=values.get("validator_count"),
+                validator_hotkeys=values.get("validator_hotkeys"),
+                average_cost_usd=values.get("average_cost_usd"),
+                average_runtime_seconds=values.get("average_runtime_seconds"),
+                disqualified=values.get("disqualified"),
+                approved_at=values.get("approved_at"),
+                performance_delta=values.get("performance_delta"),
+                cost_delta=values.get("cost_delta"),
+                relative_improvement_units=values.get("relative_improvement_units"),
+                time_multiplier=values.get("time_multiplier"),
+                initial_reward_score=values.get("initial_reward_score"),
+                baseline_agent_id=values.get("baseline_agent_id"),
+                baseline_agent_name=values.get("baseline_agent_name"),
+                baseline_agent_version_num=values.get("baseline_agent_version_num"),
+            )
+        return values
+
+    # Temporary aliases for the current FE
+    @computed_field
+    @property
+    def id(self) -> UUID:
+        return self.agent_id
+
+    @computed_field
+    @property
+    def set_id(self) -> int | None:
+        return None if self.competition_state is None else self.competition_state.set_id
+
+    @computed_field
+    @property
+    def approved(self) -> bool | None:
+        return None if self.competition_state is None else self.competition_state.approved
+
+    @computed_field
+    @property
+    def approval_review_status(self) -> ApprovalReviewStatus | None:
+        return None if self.competition_state is None else self.competition_state.approval_review_status
+
+    @computed_field
+    @property
+    def rank(self) -> int | None:
+        return None if self.competition_state is None else self.competition_state.rank
+
+    @computed_field
+    @property
+    def final_score(self) -> float | None:
+        return None if self.competition_state is None else self.competition_state.final_score
+
+    @computed_field
+    @property
+    def validator_count(self) -> int | None:
+        return None if self.competition_state is None else self.competition_state.validator_count
+
+    @computed_field
+    @property
+    def validator_hotkeys(self) -> list[str] | None:
+        return None if self.competition_state is None else self.competition_state.validator_hotkeys
+
+    @computed_field
+    @property
+    def average_cost_usd(self) -> float | None:
+        return None if self.competition_state is None else self.competition_state.average_cost_usd
+
+    @computed_field
+    @property
+    def average_runtime_seconds(self) -> float | None:
+        return None if self.competition_state is None else self.competition_state.average_runtime_seconds
+
+    @computed_field
+    @property
+    def disqualified(self) -> bool | None:
+        return None if self.competition_state is None else self.competition_state.disqualified
+
+    @computed_field
+    @property
+    def approved_at(self) -> datetime | None:
+        return None if self.competition_state is None else self.competition_state.approved_at
+
+    @computed_field
+    @property
+    def performance_delta(self) -> float | None:
+        return None if self.competition_state is None else self.competition_state.performance_delta
+
+    @computed_field
+    @property
+    def cost_delta(self) -> float | None:
+        return None if self.competition_state is None else self.competition_state.cost_delta
+
+    @computed_field
+    @property
+    def relative_improvement_units(self) -> float | None:
+        return None if self.competition_state is None else self.competition_state.relative_improvement_units
+
+    @computed_field
+    @property
+    def time_multiplier(self) -> float | None:
+        return None if self.competition_state is None else self.competition_state.time_multiplier
+
+    @computed_field
+    @property
+    def initial_reward_score(self) -> float | None:
+        return None if self.competition_state is None else self.competition_state.initial_reward_score
+
+    @computed_field
+    @property
+    def baseline_agent_id(self) -> UUID | None:
+        return None if self.competition_state is None else self.competition_state.baseline_agent_id
+
+    @computed_field
+    @property
+    def baseline_agent_name(self) -> str | None:
+        return None if self.competition_state is None else self.competition_state.baseline_agent_name
+
+    @computed_field
+    @property
+    def baseline_agent_version_num(self) -> int | None:
+        return None if self.competition_state is None else self.competition_state.baseline_agent_version_num
 
 
 class AgentCreate(AgentBase):
@@ -52,37 +371,3 @@ class AgentCreate(AgentBase):
     payment_block_hash: str
     # Index of the payment extrinsic within the block
     payment_extrinsic_index: str
-
-
-class PossiblyBenchmarkAgent(Agent):
-    is_benchmark_agent: bool
-    benchmark_description: Optional[str] = None
-    approved: bool = False
-    performance_delta: Optional[float] = None
-    cost_delta: Optional[float] = None
-    relative_improvement_units: Optional[float] = None
-    time_multiplier: Optional[float] = None
-    initial_reward_score: Optional[float] = None
-    approved_at: Optional[datetime] = None
-    baseline_agent_id: Optional[UUID] = None
-    baseline_agent_name: Optional[str] = None
-    baseline_agent_version_num: Optional[int] = None
-
-
-# TODO ADAM: need to look into this more
-
-
-class BenchmarkAgentScored(Agent):
-    benchmark_description: Optional[str] = None
-
-    set_id: int
-    approved: bool
-    validator_count: int
-    final_score: float
-
-
-class AgentScored(Agent):
-    set_id: int
-    approved: bool
-    validator_count: int
-    final_score: float

--- a/models/agent.py
+++ b/models/agent.py
@@ -219,8 +219,6 @@ class PublicAgent(BaseModel):
     version_num: int
     status: AgentStatus
     created_at: datetime
-    is_benchmark_agent: bool = False
-    benchmark_description: str | None = None
     emission: float | None = None
     reward_weight: float | None = None
     competition_state: AgentCompetitionState | None = None

--- a/models/evaluation_set.py
+++ b/models/evaluation_set.py
@@ -5,8 +5,6 @@ from uuid import UUID
 
 from pydantic import AfterValidator, BaseModel, Field
 
-from models.agent import AgentStatus
-
 
 def _r4(v: float) -> float:
     return round(float(v), 4)
@@ -121,33 +119,6 @@ class EvaluationSetDetailEfficiency(BaseModel):
     average_agent_runtime_seconds: Float4 | None
 
 
-class EvaluationSetDetailLeaderboardAgent(BaseModel):
-    rank: int | None
-    agent_id: UUID
-    miner_hotkey: str
-    name: str
-    version_num: int
-    status: AgentStatus
-    approved: bool
-    approval_review_status: str | None
-    performance_delta: Float4 | None
-    cost_delta: Float4 | None
-    relative_improvement_units: Float4 | None
-    time_multiplier: Float4 | None
-    initial_reward_score: Float4 | None
-    approved_at: datetime.datetime | None
-    baseline_agent_name: str | None
-    baseline_agent_version_num: int | None
-    final_score: Float4 | None
-    average_cost_usd: Float4 | None
-    average_runtime_seconds: Float4 | None
-    validator_count: int | None
-    validator_hotkeys: list[str]
-    created_at: datetime.datetime
-    set_id: int
-    disqualified: bool
-
-
 class EvaluationSetDetail(BaseModel):
     """Detailed information about an evaluation set, including submission statistics, scores, and comparison to the previous set."""
 
@@ -192,26 +163,3 @@ class EvaluationSetOverview(BaseModel):
     set_id: int
     performance_distribution: EvaluationSetOverviewPerformanceDistribution
     performance_improvement: list[EvaluationSetOverviewPerformanceImprovementPoint]
-
-
-class ApprovedAgent(BaseModel):
-    id: UUID
-    miner_hotkey: str
-    name: str
-    version_num: int
-    created_at: datetime.datetime
-    final_score: Float4
-    emission: float | None
-    reward_weight: float | None
-    approved_at: datetime.datetime
-    approval_review_status: str | None
-    performance_delta: Float4 | None
-    cost_delta: Float4 | None
-    relative_improvement_units: Float4 | None
-    time_multiplier: Float4 | None
-    initial_reward_score: Float4 | None
-    baseline_agent_id: UUID | None
-    baseline_agent_name: str | None
-    baseline_agent_version_num: int | None
-    average_runtime_seconds: Float4 | None
-    average_cost_usd: Float4 | None

--- a/models/validator.py
+++ b/models/validator.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from pydantic import BaseModel
 
-from models.agent import Agent
+from models.agent import PublicAgent
 from models.evaluation import Evaluation
 from utils.system_metrics import SystemMetrics
 
@@ -30,4 +30,4 @@ class ConnectedValidatorInfo(BaseModel):
     system_metrics: Optional[SystemMetrics] = None
 
     evaluation: Optional[Evaluation] = None
-    agent: Optional[Agent] = None
+    agent: Optional[PublicAgent] = None

--- a/queries/agent.py
+++ b/queries/agent.py
@@ -1,17 +1,15 @@
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Optional
+from typing import Optional
 from uuid import UUID, uuid5
 
 import api.config as config
 from models.agent import (
     Agent,
     AgentCreate,
-    AgentScored,
     AgentStatus,
-    BenchmarkAgentScored,
-    PossiblyBenchmarkAgent,
+    PublicAgent,
 )
 from models.evaluation import EvaluationStatus
 from models.evaluation_set import EvaluationSetGroup
@@ -62,7 +60,65 @@ async def get_agent_by_id(conn: DatabaseConnection, agent_id: UUID) -> Optional[
     return Agent(**result)
 
 
-LATEST_AGENT_APPROVAL_JOINS = """
+AGENT_PUBLIC_JOINS = """
+LEFT JOIN LATERAL (
+    SELECT COALESCE(
+        a.set_id,
+        (
+            SELECT aa.set_id
+            FROM approved_agents aa
+            WHERE aa.agent_id = a.agent_id
+            ORDER BY aa.set_id DESC
+            LIMIT 1
+        ),
+        (
+            SELECT afr.set_id
+            FROM agent_final_review_statuses afr
+            WHERE afr.agent_id = a.agent_id
+            ORDER BY afr.updated_at DESC, afr.set_id DESC
+            LIMIT 1
+        ),
+        (SELECT ass.set_id FROM agent_scores ass WHERE ass.agent_id = a.agent_id),
+        (SELECT MAX(e.set_id) FROM evaluations e WHERE e.agent_id = a.agent_id)
+    ) AS set_id
+) competition_context ON TRUE
+LEFT JOIN agent_final_review_statuses competition_review
+    ON competition_review.agent_id = a.agent_id
+   AND competition_review.set_id = competition_context.set_id
+LEFT JOIN agent_scores competition_score
+    ON competition_score.agent_id = a.agent_id
+   AND competition_score.set_id = competition_context.set_id
+LEFT JOIN approved_agents competition_approval
+    ON competition_approval.agent_id = a.agent_id
+   AND competition_approval.set_id = competition_context.set_id
+LEFT JOIN agents competition_baseline
+    ON competition_baseline.agent_id = competition_approval.baseline_agent_id
+"""
+
+AGENT_PUBLIC_SELECT_COLUMNS = """
+    a.agent_id,
+    a.miner_hotkey,
+    a.name,
+    a.version_num,
+    a.status,
+    a.created_at,
+    competition_context.set_id,
+    competition_score.validator_count,
+    competition_score.final_score,
+    competition_review.approval_review_status,
+    (competition_approval.agent_id IS NOT NULL) AS approved,
+    competition_approval.performance_delta,
+    competition_approval.cost_delta,
+    competition_approval.relative_improvement_units,
+    competition_approval.time_multiplier,
+    competition_approval.initial_reward_score,
+    competition_approval.approved_at,
+    competition_approval.baseline_agent_id,
+    competition_baseline.name AS baseline_agent_name,
+    competition_baseline.version_num AS baseline_agent_version_num
+"""
+
+LATEST_AGENT_REVIEW_JOIN = """
 LEFT JOIN LATERAL (
     SELECT approval_review_status
     FROM agent_final_review_statuses
@@ -74,39 +130,13 @@ LEFT JOIN LATERAL (
 
 
 @db_operation
-async def get_possibly_benchmark_agent_by_id(
-    conn: DatabaseConnection, agent_id: UUID
-) -> Optional[PossiblyBenchmarkAgent]:
+async def get_public_agent_by_id(conn: DatabaseConnection, agent_id: UUID) -> PublicAgent | None:
     result = await conn.fetchrow(
         f"""
         SELECT
-            a.*,
-            latest_review.approval_review_status AS approval_review_status,
-            (bai.agent_id IS NOT NULL) AS is_benchmark_agent,
-            bai.description AS benchmark_description,
-            (latest_approval.agent_id IS NOT NULL) AS approved,
-            latest_approval.performance_delta,
-            latest_approval.cost_delta,
-            latest_approval.relative_improvement_units,
-            latest_approval.time_multiplier,
-            latest_approval.initial_reward_score,
-            latest_approval.approved_at,
-            latest_approval.baseline_agent_id,
-            baseline.name AS baseline_agent_name,
-            baseline.version_num AS baseline_agent_version_num
+            {AGENT_PUBLIC_SELECT_COLUMNS}
         FROM agents a
-        LEFT JOIN benchmark_agent_ids bai ON a.agent_id = bai.agent_id
-        {LATEST_AGENT_APPROVAL_JOINS}
-        LEFT JOIN LATERAL (
-            SELECT aa.agent_id, aa.baseline_agent_id, aa.performance_delta, aa.cost_delta,
-                   aa.relative_improvement_units, aa.time_multiplier, aa.initial_reward_score,
-                   aa.approved_at
-            FROM approved_agents aa
-            WHERE aa.agent_id = a.agent_id
-            ORDER BY aa.set_id DESC
-            LIMIT 1
-        ) latest_approval ON TRUE
-        LEFT JOIN agents baseline ON baseline.agent_id = latest_approval.baseline_agent_id
+        {AGENT_PUBLIC_JOINS}
         WHERE a.agent_id = $1
         LIMIT 1
         """,
@@ -116,18 +146,17 @@ async def get_possibly_benchmark_agent_by_id(
     if result is None:
         return None
 
-    return PossiblyBenchmarkAgent(**result)
+    return PublicAgent(**result)
 
 
 @db_operation
-async def get_agent_by_evaluation_run_id(conn: DatabaseConnection, evaluation_run_id: UUID) -> Optional[Agent]:
+async def get_agent_by_evaluation_run_id(conn: DatabaseConnection, evaluation_run_id: UUID) -> PublicAgent | None:
     result = await conn.fetchrow(
         f"""
         SELECT
-            a.*,
-            latest_review.approval_review_status AS approval_review_status
+            {AGENT_PUBLIC_SELECT_COLUMNS}
         FROM agents a
-        {LATEST_AGENT_APPROVAL_JOINS}
+        {AGENT_PUBLIC_JOINS}
         WHERE a.agent_id = (
             SELECT agent_id FROM evaluations WHERE evaluation_id = (
                 SELECT evaluation_id FROM evaluation_runs WHERE evaluation_run_id = $1 LIMIT 1
@@ -140,36 +169,36 @@ async def get_agent_by_evaluation_run_id(conn: DatabaseConnection, evaluation_ru
     if result is None:
         return None
 
-    return Agent(**result)
+    return PublicAgent(**result)
 
 
 @db_operation
-async def get_all_agents_by_miner_hotkey(conn: DatabaseConnection, miner_hotkey: str) -> List[Agent]:
+async def get_all_public_agents_by_miner_hotkey(conn: DatabaseConnection, miner_hotkey: str) -> list[PublicAgent]:
     result = await conn.fetch(
         f"""
         SELECT
-            a.*,
-            latest_review.approval_review_status AS approval_review_status
+            {AGENT_PUBLIC_SELECT_COLUMNS}
         FROM agents a
-        {LATEST_AGENT_APPROVAL_JOINS}
+        {AGENT_PUBLIC_JOINS}
         WHERE a.miner_hotkey = $1
         ORDER BY a.created_at DESC
         """,
         miner_hotkey,
     )
 
-    return [Agent(**agent) for agent in result]
+    return [PublicAgent(**agent) for agent in result]
 
 
 @db_operation
 async def get_latest_agent_for_miner_hotkey(conn: DatabaseConnection, miner_hotkey: str) -> Optional[Agent]:
+    """Return the core latest-agent model used by upload/platform machinery."""
     result = await conn.fetchrow(
         f"""
         SELECT
             a.*,
             latest_review.approval_review_status AS approval_review_status
         FROM agents a
-        {LATEST_AGENT_APPROVAL_JOINS}
+        {LATEST_AGENT_REVIEW_JOIN}
         WHERE a.miner_hotkey = $1
         ORDER BY a.created_at DESC
         LIMIT 1
@@ -181,6 +210,28 @@ async def get_latest_agent_for_miner_hotkey(conn: DatabaseConnection, miner_hotk
         return None
 
     return Agent(**result)
+
+
+@db_operation
+async def get_latest_public_agent_for_miner_hotkey(conn: DatabaseConnection, miner_hotkey: str) -> PublicAgent | None:
+    """Return the latest agent enriched for public competition views."""
+    result = await conn.fetchrow(
+        f"""
+        SELECT
+            {AGENT_PUBLIC_SELECT_COLUMNS}
+        FROM agents a
+        {AGENT_PUBLIC_JOINS}
+        WHERE a.miner_hotkey = $1
+        ORDER BY a.created_at DESC
+        LIMIT 1
+        """,
+        miner_hotkey,
+    )
+
+    if result is None:
+        return None
+
+    return PublicAgent(**result)
 
 
 @db_operation
@@ -445,24 +496,6 @@ async def update_agent_status(conn: DatabaseConnection, agent_id: UUID, status: 
     )
 
 
-@db_operation
-async def get_benchmark_agents(conn: DatabaseConnection) -> List[BenchmarkAgentScored]:
-    result = await conn.fetch(
-        """
-        SELECT
-            ass.*,
-            NULL::text AS approval_review_status,
-            bai.description AS benchmark_description
-        FROM agent_scores ass
-        LEFT JOIN benchmark_agent_ids bai ON ass.agent_id = bai.agent_id
-        WHERE ass.agent_id IN (SELECT agent_id FROM benchmark_agent_ids)
-        ORDER BY ass.created_at DESC, ass.final_score DESC
-        """
-    )
-
-    return [BenchmarkAgentScored(**agent) for agent in result]
-
-
 # TODO ADAM: fix this section
 
 
@@ -497,7 +530,7 @@ async def record_upload_attempt(conn: DatabaseConnection, upload_type: str, succ
 
 
 @db_operation
-async def get_top_agents(conn: DatabaseConnection, number_of_agents: int = 10, page: int = 1) -> list[AgentScored]:
+async def get_top_agents(conn: DatabaseConnection, number_of_agents: int = 10, page: int = 1) -> list[PublicAgent]:
     """Retrieve the top agents.
 
     Agents are ordered by validator score, then average validator-evaluation cost, then creation time.
@@ -515,7 +548,7 @@ async def get_top_agents(conn: DatabaseConnection, number_of_agents: int = 10, p
 
     Returns
     -------
-    list[AgentScored]
+    list[PublicAgent]
         List of top agents with their scores.
     """
     # TODO ADAM: this query was supposed to be fixed to remove the pagination concept
@@ -525,13 +558,35 @@ async def get_top_agents(conn: DatabaseConnection, number_of_agents: int = 10, p
     results = await conn.fetch(
         """
         select
-            ass.*,
-            review.approval_review_status AS approval_review_status
+            ass.agent_id,
+            ass.miner_hotkey,
+            ass.name,
+            ass.version_num,
+            ass.status,
+            ass.created_at,
+            ass.set_id,
+            (approval.agent_id is not null) as approved,
+            ass.validator_count,
+            ass.final_score,
+            review.approval_review_status,
+            approval.performance_delta,
+            approval.cost_delta,
+            approval.relative_improvement_units,
+            approval.time_multiplier,
+            approval.initial_reward_score,
+            approval.approved_at,
+            approval.baseline_agent_id,
+            baseline.name as baseline_agent_name,
+            baseline.version_num as baseline_agent_version_num
         from agent_scores ass
         join agents a on a.agent_id = ass.agent_id
         left join agent_final_review_statuses review
             on review.agent_id = ass.agent_id
            and review.set_id = ass.set_id
+        left join approved_agents approval
+            on approval.agent_id = ass.agent_id
+           and approval.set_id = ass.set_id
+        left join agents baseline on baseline.agent_id = approval.baseline_agent_id
         left join lateral (
             select avg(eh.avg_cost_usd) as avg_cost_usd
             from evaluations_hydrated eh
@@ -548,10 +603,7 @@ async def get_top_agents(conn: DatabaseConnection, number_of_agents: int = 10, p
             where bc.miner_coldkey = a.miner_coldkey
         )
         and ass.status::text <> 'cancelled'
-        and (
-            ass.approved is true
-            or review.approval_review_status is distinct from 'rejected'
-        )
+        and review.approval_review_status is distinct from 'rejected'
         order by
             round(ass.final_score::numeric, 6) desc,
             rt.avg_cost_usd asc nulls last,
@@ -562,7 +614,7 @@ async def get_top_agents(conn: DatabaseConnection, number_of_agents: int = 10, p
         offset,
     )
 
-    return [AgentScored(**agent) for agent in results]
+    return [PublicAgent(**agent) for agent in results]
 
 
 @db_operation

--- a/queries/evaluation_set.py
+++ b/queries/evaluation_set.py
@@ -908,6 +908,7 @@ async def get_evaluation_set_leaderboard_agents(conn: DatabaseConnection, set_id
             aa.time_multiplier,
             aa.initial_reward_score,
             aa.approved_at,
+            aa.baseline_agent_id,
             baseline.name AS baseline_agent_name,
             baseline.version_num AS baseline_agent_version_num,
             rs.final_score,

--- a/tests/api/test_auto_approval.py
+++ b/tests/api/test_auto_approval.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import pytest
 
 from api.endpoints import validator as validator_endpoint
-from models.agent import Agent, AgentStatus
+from models.agent import Agent, AgentCompetitionState, AgentCompetitionStatus, AgentStatus, PublicAgent
 from models.evaluation import EvaluationStatus, HydratedEvaluation
 from models.evaluation_set import EvaluationSetGroup
 from queries.evaluation import AgentRankingProfile
@@ -44,6 +44,63 @@ def _agent(*, agent_id, status: AgentStatus) -> Agent:
         created_at=datetime.now(timezone.utc),
         ip_address="127.0.0.1",
     )
+
+
+@pytest.mark.anyio
+async def test_screening_2_completion_uses_top_eligible_agent(monkeypatch) -> None:
+    agent_id = uuid4()
+    hydrated = _hydrated_evaluation(agent_id=agent_id)
+    transitions: list[tuple] = []
+    top_agent_calls: list[int] = []
+
+    async def fake_update_evaluation_finished_at(_evaluation_id) -> None:
+        return None
+
+    async def fake_get_hydrated_evaluation_by_id(_evaluation_id):
+        return hydrated
+
+    async def fake_get_agent_by_id(_agent_id):
+        return _agent(agent_id=agent_id, status=AgentStatus.screening_2)
+
+    async def fake_get_top_agents(*, number_of_agents):
+        top_agent_calls.append(number_of_agents)
+        return [
+            PublicAgent(
+                agent_id=uuid4(),
+                miner_hotkey="leader-hotkey",
+                name="Leader",
+                version_num=1,
+                status=AgentStatus.finished,
+                created_at=datetime.now(timezone.utc),
+                competition_state=AgentCompetitionState(
+                    set_id=7,
+                    status=AgentCompetitionStatus.approved,
+                    approved=True,
+                    final_score=0.9,
+                ),
+            )
+        ]
+
+    async def fake_transition_agent_status_if_matches(_agent_id, expected_status, new_status):
+        transitions.append((_agent_id, expected_status, new_status))
+        return True
+
+    monkeypatch.setattr(validator_endpoint, "update_evaluation_finished_at", fake_update_evaluation_finished_at)
+    monkeypatch.setattr(validator_endpoint, "get_hydrated_evaluation_by_id", fake_get_hydrated_evaluation_by_id)
+    monkeypatch.setattr(validator_endpoint, "get_agent_by_id", fake_get_agent_by_id)
+    monkeypatch.setattr(validator_endpoint, "get_top_agents", fake_get_top_agents)
+    monkeypatch.setattr(
+        validator_endpoint,
+        "transition_agent_status_if_matches",
+        fake_transition_agent_status_if_matches,
+    )
+    monkeypatch.setattr(validator_endpoint.config, "SCREENER_2_THRESHOLD", 0.6)
+    monkeypatch.setattr(validator_endpoint.config, "PRUNE_THRESHOLD", 0.9)
+
+    await validator_endpoint.handle_evaluation_if_finished(hydrated.evaluation_id)
+
+    assert top_agent_calls == [1]
+    assert transitions == [(agent_id, AgentStatus.screening_2, AgentStatus.evaluating)]
 
 
 @pytest.mark.anyio

--- a/tests/api/test_evaluation_sets.py
+++ b/tests/api/test_evaluation_sets.py
@@ -562,7 +562,17 @@ async def test_evaluation_set_detail_happy_path():
     assert result.submissions.approved_emission_count == 1
 
     # Pipeline
+    assert [stage.stage for stage in result.submissions.pipeline] == [
+        "total",
+        "pre_screening",
+        "screener_1",
+        "screener_2",
+        "validator",
+        "approved_emission",
+    ]
     stages = {s.stage: s for s in result.submissions.pipeline}
+    assert stages["total"].count == 3
+    assert stages["total"].pass_rate == 1
     assert stages["pre_screening"].count == 2
     assert stages["pre_screening"].pass_rate == pytest.approx(2 / 3, rel=1e-3)
     assert stages["screener_1"].count == 2

--- a/tests/api/test_evaluation_sets.py
+++ b/tests/api/test_evaluation_sets.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 
 import api.endpoints.evaluation_sets as evaluation_sets_endpoint
 import utils.database as _db
+from models.agent import AgentStatus
 from utils.bittensor import HotkeySubnetInfo
 
 
@@ -616,20 +617,30 @@ async def test_evaluation_set_detail_happy_path():
     leaderboard = await evaluation_sets_endpoint.evaluation_set_leaderboard(set_id=2)
     agents_by_id = {agent.agent_id: agent for agent in leaderboard}
     assert set(agents_by_id) == {agent_a, agent_b, agent_c}
-    assert agents_by_id[agent_a].rank == 1
-    assert agents_by_id[agent_a].approved is True
-    assert agents_by_id[agent_a].approved_at == leaderboard_approved_at
-    assert agents_by_id[agent_a].final_score == 0.8
-    assert agents_by_id[agent_a].validator_count == 1
-    assert agents_by_id[agent_a].average_cost_usd == 0.2
-    assert agents_by_id[agent_a].average_runtime_seconds == 75
-    assert agents_by_id[agent_a].validator_hotkeys == ["validator-hotkey"]
-    assert agents_by_id[agent_b].rank is None
-    assert agents_by_id[agent_b].approved_at is None
-    assert agents_by_id[agent_b].final_score is None
-    assert agents_by_id[agent_c].rank is None
-    assert agents_by_id[agent_c].approved_at is None
-    assert agents_by_id[agent_c].final_score is None
+    agent_a_state = agents_by_id[agent_a].competition_state
+    assert agent_a_state is not None
+    assert agent_a_state.rank == 1
+    assert agent_a_state.approved is True
+    assert agent_a_state.approved_at == leaderboard_approved_at
+    assert agent_a_state.final_score == 0.8
+    assert agent_a_state.validator_count == 1
+    assert agent_a_state.average_cost_usd == 0.2
+    assert agent_a_state.average_runtime_seconds == 75
+    assert agent_a_state.validator_hotkeys == ["validator-hotkey"]
+    assert agent_a_state.status == "approved"
+    assert agent_a_state.set_id == 2
+    agent_b_state = agents_by_id[agent_b].competition_state
+    assert agent_b_state is not None
+    assert agent_b_state.rank is None
+    assert agent_b_state.approved_at is None
+    assert agent_b_state.final_score is None
+    assert agent_b_state.status == "failed_screening_2"
+    agent_c_state = agents_by_id[agent_c].competition_state
+    assert agent_c_state is not None
+    assert agent_c_state.rank is None
+    assert agent_c_state.approved_at is None
+    assert agent_c_state.final_score is None
+    assert agent_c_state.status == "failed_pre_screening"
 
 
 @pytest.mark.anyio
@@ -732,7 +743,11 @@ async def test_evaluation_set_leaderboard_ranks_by_score_cost_then_submission_ti
 
     leaderboard = await evaluation_sets_endpoint.evaluation_set_leaderboard(set_id=2)
 
-    ranked_agent_ids = [agent.agent_id for agent in leaderboard if agent.rank is not None]
+    ranked_agent_ids = [
+        agent.agent_id
+        for agent in leaderboard
+        if agent.competition_state is not None and agent.competition_state.rank is not None
+    ]
     assert ranked_agent_ids == [
         high_score_agent,
         lower_cost_tie_agent,
@@ -742,8 +757,9 @@ async def test_evaluation_set_leaderboard_ranks_by_score_cost_then_submission_ti
     ]
 
     agents_by_id = {agent.agent_id: agent for agent in leaderboard}
-    assert agents_by_id[unscored_agent].rank is None
-    assert agents_by_id[unscored_agent].final_score is None
+    assert agents_by_id[unscored_agent].competition_state is not None
+    assert agents_by_id[unscored_agent].competition_state.rank is None
+    assert agents_by_id[unscored_agent].competition_state.final_score is None
 
     result = await evaluation_sets_endpoint.evaluation_set_detail(set_id=2)
     assert result.efficiency.lowest_average_cost_usd_top_agents is not None
@@ -803,10 +819,12 @@ async def test_coldkey_ban_disqualifies_competitor_and_removes_approved_output()
 
     leaderboard = await evaluation_sets_endpoint.evaluation_set_leaderboard(set_id=2)
     by_id = {agent.agent_id: agent for agent in leaderboard}
-    assert by_id[banned_agent].disqualified is True
-    assert by_id[banned_agent].rank is None
-    assert by_id[eligible_agent].disqualified is False
-    assert by_id[eligible_agent].rank == 1
+    assert by_id[banned_agent].competition_state is not None
+    assert by_id[banned_agent].competition_state.disqualified is True
+    assert by_id[banned_agent].competition_state.rank is None
+    assert by_id[eligible_agent].competition_state is not None
+    assert by_id[eligible_agent].competition_state.disqualified is False
+    assert by_id[eligible_agent].competition_state.rank == 1
 
     detail = await evaluation_sets_endpoint.evaluation_set_detail(set_id=2)
     assert detail.scores.best == 0.8
@@ -815,7 +833,7 @@ async def test_coldkey_ban_disqualifies_competitor_and_removes_approved_output()
     assert detail.top_agent.agent_id == eligible_agent
 
     approved_agents = await evaluation_sets_endpoint.evaluation_set_approved_agents(set_id=2)
-    assert [agent.id for agent in approved_agents] == [eligible_agent]
+    assert [agent.agent_id for agent in approved_agents] == [eligible_agent]
 
 
 @pytest.mark.anyio
@@ -860,7 +878,16 @@ async def test_evaluation_set_detail_efficiency_uses_all_ranked_agents_not_top_2
             )
 
     leaderboard = await evaluation_sets_endpoint.evaluation_set_leaderboard(set_id=2)
-    assert len([agent for agent in leaderboard if agent.rank is not None]) == 26
+    assert (
+        len(
+            [
+                agent
+                for agent in leaderboard
+                if agent.competition_state is not None and agent.competition_state.rank is not None
+            ]
+        )
+        == 26
+    )
 
     result = await evaluation_sets_endpoint.evaluation_set_detail(set_id=2)
     assert result.efficiency.lowest_average_cost_usd_top_agents is not None
@@ -941,8 +968,9 @@ async def test_evaluation_set_detail_no_scores_returns_null_best_and_average():
     leaderboard = await evaluation_sets_endpoint.evaluation_set_leaderboard(set_id=2)
     assert len(leaderboard) == 1
     assert leaderboard[0].agent_id == agent_a
-    assert leaderboard[0].rank is None
-    assert leaderboard[0].final_score is None
+    assert leaderboard[0].competition_state is not None
+    assert leaderboard[0].competition_state.rank is None
+    assert leaderboard[0].competition_state.final_score is None
 
 
 @pytest.mark.anyio
@@ -1044,75 +1072,72 @@ async def test_evaluation_set_approved_agents_returns_approved_agents(monkeypatc
 
     assert len(result) == 2
     # Ordered by approved_at DESC (agent_a was the latest approved)
-    assert result[0].id == agent_id_a
+    assert result[0].agent_id == agent_id_a
     assert result[0].miner_hotkey == "hotkey-a"
-    assert result[0].final_score == 90.0
     assert result[0].emission == pytest.approx(147.600823658)
     assert result[0].reward_weight == pytest.approx(0.7)
-    assert result[0].approved_at == approved_at_a
-    assert result[0].approval_review_status == "approved"
-    assert result[0].performance_delta == 0.1235
-    assert result[0].cost_delta == 0.0654
-    assert result[0].relative_improvement_units == 1.2346
-    assert result[0].time_multiplier == 1.4568
-    assert result[0].initial_reward_score == 2.3457
-    assert result[0].baseline_agent_id == agent_id_b
-    assert result[0].baseline_agent_name == "hotkey-b"
-    assert result[0].baseline_agent_version_num == 1
-    assert result[0].average_cost_usd == 0.5
-    assert result[0].average_runtime_seconds == 120
+    first_state = result[0].competition_state
+    assert first_state is not None
+    assert first_state.final_score == 90.0
+    assert first_state.approved_at == approved_at_a
+    assert first_state.approval_review_status == "approved"
+    assert first_state.performance_delta == 0.123456
+    assert first_state.cost_delta == 0.065432
+    assert first_state.relative_improvement_units == 1.234567
+    assert first_state.time_multiplier == 1.456789
+    assert first_state.initial_reward_score == 2.34567
+    assert first_state.baseline_agent_id == agent_id_b
+    assert first_state.baseline_agent_name == "hotkey-b"
+    assert first_state.baseline_agent_version_num == 1
+    assert first_state.average_cost_usd == 0.5
+    assert first_state.average_runtime_seconds == 120
+    assert first_state.status == "approved"
+    assert first_state.set_id == 1
 
-    assert result[1].id == agent_id_b
+    assert result[1].agent_id == agent_id_b
     assert result[1].miner_hotkey == "hotkey-b"
-    assert result[1].final_score == 70.0
     assert result[1].emission == pytest.approx(2.037068052)
     assert result[1].reward_weight == pytest.approx(0.3)
-    assert result[1].approved_at == approved_at_b
-    assert result[1].approval_review_status is None
-    assert result[1].performance_delta is None
-    assert result[1].cost_delta is None
-    assert result[1].relative_improvement_units is None
-    assert result[1].time_multiplier is None
-    assert result[1].initial_reward_score is None
-    assert result[1].baseline_agent_id is None
-    assert result[1].baseline_agent_name is None
-    assert result[1].baseline_agent_version_num is None
-    assert result[1].average_cost_usd == 0.3
-    assert result[1].average_runtime_seconds == 60
+    second_state = result[1].competition_state
+    assert second_state is not None
+    assert second_state.final_score == 70.0
+    assert second_state.approved_at == approved_at_b
+    assert second_state.approval_review_status is None
+    assert second_state.performance_delta is None
+    assert second_state.cost_delta is None
+    assert second_state.relative_improvement_units is None
+    assert second_state.time_multiplier is None
+    assert second_state.initial_reward_score is None
+    assert second_state.baseline_agent_id is None
+    assert second_state.baseline_agent_name is None
+    assert second_state.baseline_agent_version_num is None
+    assert second_state.average_cost_usd == 0.3
+    assert second_state.average_runtime_seconds == 60
+    assert second_state.status == "approved"
+    assert second_state.set_id == 1
 
 
 @pytest.mark.anyio
 async def test_live_approved_agents_show_individual_weights_for_shared_hotkey(monkeypatch):
     first_agent_id = uuid4()
     second_agent_id = uuid4()
-    first_agent = evaluation_sets_endpoint.ApprovedAgent(
-        id=first_agent_id,
+    first_agent = evaluation_sets_endpoint.PublicAgent(
+        agent_id=first_agent_id,
         miner_hotkey="shared-hotkey",
         name="first-agent",
         version_num=1,
+        status=AgentStatus.finished,
         created_at=AGENT_TS_SET_1,
+        set_id=1,
+        approved=True,
         final_score=0.8,
-        emission=None,
-        reward_weight=None,
         approved_at=AGENT_TS_SET_1,
-        approval_review_status=None,
-        performance_delta=None,
-        cost_delta=None,
-        relative_improvement_units=None,
-        time_multiplier=None,
-        initial_reward_score=None,
-        baseline_agent_id=None,
-        baseline_agent_name=None,
-        baseline_agent_version_num=None,
-        average_runtime_seconds=None,
-        average_cost_usd=None,
     )
     second_agent = first_agent.model_copy(
         update={
-            "id": second_agent_id,
+            "agent_id": second_agent_id,
             "name": "second-agent",
             "version_num": 2,
-            "final_score": 0.9,
         }
     )
 
@@ -1137,27 +1162,17 @@ async def test_live_approved_agents_show_individual_weights_for_shared_hotkey(mo
 @pytest.mark.anyio
 async def test_live_approved_agent_data_degrades_when_chain_lookup_fails(monkeypatch):
     agent_id = uuid4()
-    agent = evaluation_sets_endpoint.ApprovedAgent(
-        id=agent_id,
+    agent = evaluation_sets_endpoint.PublicAgent(
+        agent_id=agent_id,
         miner_hotkey="hotkey",
         name="agent",
         version_num=1,
+        status=AgentStatus.finished,
         created_at=AGENT_TS_SET_1,
+        set_id=1,
+        approved=True,
         final_score=0.9,
-        emission=None,
-        reward_weight=None,
         approved_at=AGENT_TS_SET_1,
-        approval_review_status=None,
-        performance_delta=None,
-        cost_delta=None,
-        relative_improvement_units=None,
-        time_multiplier=None,
-        initial_reward_score=None,
-        baseline_agent_id=None,
-        baseline_agent_name=None,
-        baseline_agent_version_num=None,
-        average_runtime_seconds=None,
-        average_cost_usd=None,
     )
 
     async def fail_chain_lookup():

--- a/tests/api/test_retrieval_queue.py
+++ b/tests/api/test_retrieval_queue.py
@@ -41,6 +41,8 @@ async def test_get_agents_in_pre_screening_queue_uses_stage_view() -> None:
     result = await agent_queries.get_agents_in_queue.__wrapped__(conn, QueueStage.pre_screening)
 
     assert [agent.status for agent in result] == [AgentStatus.pre_screening]
+    assert "competition_state" not in result[0].model_dump()
+    assert "approved" not in result[0].model_dump()
     assert conn.args == ()
     assert conn.query is not None
     assert "join pre_screening_queue q" in conn.query

--- a/tests/api/test_score_bound_cancellation.py
+++ b/tests/api/test_score_bound_cancellation.py
@@ -176,7 +176,11 @@ async def test_score_bound_pruning_screener_2_uses_screener_threshold(monkeypatc
     monkeypatch.setattr(
         validator_endpoint, "transition_agent_status_if_matches", fake_transition_agent_status_if_matches
     )
-    monkeypatch.setattr(validator_endpoint, "get_top_agents", fail_if_top_agents_called)
+    monkeypatch.setattr(
+        validator_endpoint,
+        "get_top_agents",
+        fail_if_top_agents_called,
+    )
 
     assert await validator_endpoint._maybe_stop_agent_by_score_bound(evaluation) is True
     assert status_updates == [(agent_id, AgentStatus.screening_2, AgentStatus.failed_screening_2)]

--- a/tests/queries/test_cost_tiebreak_ranking.py
+++ b/tests/queries/test_cost_tiebreak_ranking.py
@@ -62,7 +62,8 @@ async def test_top_agents_uses_cost_tiebreaker() -> None:
     result = await agent_queries.get_top_agents.__wrapped__(conn, number_of_agents=10, page=2)
 
     assert len(result) == 1
-    assert result[0].approval_review_status is None
+    assert result[0].competition_state is not None
+    assert result[0].competition_state.approval_review_status is None
     assert conn.args == (10, 10)
     assert conn.query is not None
     _assert_cost_tiebreak_query(conn.query)
@@ -70,5 +71,5 @@ async def test_top_agents_uses_cost_tiebreaker() -> None:
     assert "ass.status::text <> 'cancelled'" in query
     assert "approval_review_status" in query
     assert "agent_final_review_statuses" in query
-    assert "ass.approved is true" in query
+    assert "ass.approved is true" not in query
     assert "approval_review_status is distinct from 'rejected'" in query

--- a/tests/queries/test_public_agent_context.py
+++ b/tests/queries/test_public_agent_context.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+import utils.database as _db
+from queries.agent import get_public_agent_by_id
+
+
+@pytest.fixture(autouse=True)
+async def clean_tables(postgres_db):
+    async with _db.pool.acquire() as conn:
+        await conn.execute("TRUNCATE agents, competitions RESTART IDENTITY CASCADE")
+    yield
+    async with _db.pool.acquire() as conn:
+        await conn.execute("TRUNCATE agents, competitions RESTART IDENTITY CASCADE")
+
+
+async def _insert_agent(conn, *, miner_hotkey: str, set_id: int | None = None) -> UUID:
+    agent_id = uuid4()
+    await conn.execute(
+        """
+        INSERT INTO agents (
+            agent_id, miner_hotkey, name, version_num, status,
+            created_at, ip_address, set_id
+        )
+        VALUES ($1, $2, $2, 1, 'finished', NOW(), '127.0.0.1', $3)
+        """,
+        agent_id,
+        miner_hotkey,
+        set_id,
+    )
+    return agent_id
+
+
+async def _insert_evaluation(conn, *, agent_id: UUID, set_id: int) -> None:
+    await conn.execute(
+        """
+        INSERT INTO evaluations (
+            evaluation_id, agent_id, validator_hotkey, set_id,
+            evaluation_set_group, created_at
+        )
+        VALUES ($1, $2, 'validator-hotkey', $3, 'validator', NOW())
+        """,
+        uuid4(),
+        agent_id,
+        set_id,
+    )
+
+
+async def _insert_score(conn, *, agent_id: UUID, miner_hotkey: str, set_id: int) -> None:
+    await conn.execute(
+        """
+        INSERT INTO agent_scores (
+            agent_id, miner_hotkey, name, version_num, created_at, status,
+            set_id, approved, validator_count, final_score
+        )
+        VALUES ($1, $2, $2, 1, NOW(), 'finished', $3, false, 1, 0.5)
+        """,
+        agent_id,
+        miner_hotkey,
+        set_id,
+    )
+
+
+async def _insert_review(conn, *, agent_id: UUID, set_id: int) -> None:
+    await conn.execute(
+        """
+        INSERT INTO agent_approval_states (
+            agent_id, set_id, processing_status, updated_at
+        )
+        VALUES ($1, $2, 'needs_review', NOW())
+        """,
+        agent_id,
+        set_id,
+    )
+
+
+async def _insert_approval(conn, *, agent_id: UUID, set_id: int) -> None:
+    await conn.execute(
+        """
+        INSERT INTO approved_agents (
+            agent_id, set_id, approved_at, relative_improvement_units
+        )
+        VALUES ($1, $2, NOW(), 1.5)
+        """,
+        agent_id,
+        set_id,
+    )
+
+
+@pytest.mark.anyio
+async def test_modern_agent_uses_its_recorded_set_as_public_context() -> None:
+    async with _db.pool.acquire() as conn:
+        await conn.execute("INSERT INTO competitions (set_id) VALUES (100)")
+        agent_id = await _insert_agent(conn, miner_hotkey="modern-hotkey", set_id=100)
+
+        # Deliberately inconsistent related rows must not move a modern agent
+        # away from the competition captured when it was uploaded.
+        await _insert_evaluation(conn, agent_id=agent_id, set_id=101)
+        await _insert_approval(conn, agent_id=agent_id, set_id=101)
+
+    agent = await get_public_agent_by_id(agent_id)
+
+    assert agent is not None
+    assert agent.status == "finished"
+    assert agent.competition_state is not None
+    assert agent.competition_state.set_id == 100
+    assert agent.competition_state.status == "didnt_qualify"
+    assert agent.competition_state.approved is False
+    assert agent.competition_state.relative_improvement_units is None
+
+
+@pytest.mark.anyio
+async def test_legacy_agent_context_follows_public_detail_compatibility_order() -> None:
+    async with _db.pool.acquire() as conn:
+        approval_agent = await _insert_agent(conn, miner_hotkey="approval-hotkey")
+        review_agent = await _insert_agent(conn, miner_hotkey="review-hotkey")
+        score_agent = await _insert_agent(conn, miner_hotkey="score-hotkey")
+        evaluation_agent = await _insert_agent(conn, miner_hotkey="evaluation-hotkey")
+
+        for agent_id in (approval_agent, review_agent, score_agent, evaluation_agent):
+            await _insert_evaluation(conn, agent_id=agent_id, set_id=103)
+
+        await _insert_approval(conn, agent_id=approval_agent, set_id=100)
+        await _insert_review(conn, agent_id=approval_agent, set_id=101)
+        await _insert_score(conn, agent_id=approval_agent, miner_hotkey="approval-hotkey", set_id=102)
+
+        await _insert_review(conn, agent_id=review_agent, set_id=101)
+        await _insert_score(conn, agent_id=review_agent, miner_hotkey="review-hotkey", set_id=102)
+
+        await _insert_score(conn, agent_id=score_agent, miner_hotkey="score-hotkey", set_id=102)
+
+    approval = await get_public_agent_by_id(approval_agent)
+    review = await get_public_agent_by_id(review_agent)
+    score = await get_public_agent_by_id(score_agent)
+    evaluation = await get_public_agent_by_id(evaluation_agent)
+
+    assert approval is not None and approval.competition_state is not None
+    assert approval.competition_state.set_id == 100
+    assert approval.competition_state.status == "baseline"
+    assert approval.competition_state.approved is True
+
+    assert review is not None and review.competition_state is not None
+    assert review.competition_state.set_id == 101
+    assert review.competition_state.status == "under_review"
+
+    assert score is not None and score.competition_state is not None
+    assert score.competition_state.set_id == 102
+    assert score.competition_state.status == "didnt_qualify"
+    assert score.competition_state.final_score == 0.5
+
+    assert evaluation is not None and evaluation.competition_state is not None
+    assert evaluation.competition_state.set_id == 103
+    assert evaluation.competition_state.status == "didnt_qualify"

--- a/tests/queries/test_scores.py
+++ b/tests/queries/test_scores.py
@@ -7,7 +7,12 @@ from uuid import UUID, uuid4
 import pytest
 
 import utils.database as _db
-from queries.agent import get_top_agents
+from models.agent import Agent, PublicAgent
+from queries.agent import (
+    get_latest_agent_for_miner_hotkey,
+    get_latest_public_agent_for_miner_hotkey,
+    get_top_agents,
+)
 from queries.banned_coldkey import ban_coldkey, unban_coldkey
 from queries.evaluation import get_approved_leader_ranking_for_set, get_approved_validator_leader_score_for_set
 from queries.scores import (
@@ -359,15 +364,83 @@ async def test_top_agents_uses_coldkey_bans_at_read_time():
             approved_at=now - timedelta(hours=1),
             created_at=SET_CREATED_AT + timedelta(hours=2),
         )
+        await conn.execute(
+            """
+            INSERT INTO agent_approval_states (
+                agent_id, set_id, processing_status, system_verdict, published_verdict
+            ) VALUES ($1, $2, 'completed', 'rejected', 'rejected')
+            """,
+            eligible_id,
+            SET_ID - 1,
+        )
 
     await ban_coldkey("banned-leader-coldkey", "test ban")
-    assert [agent.agent_id for agent in await get_top_agents()] == [eligible_id]
+    agents = await get_top_agents()
+    assert [agent.agent_id for agent in agents] == [eligible_id]
+    assert agents[0].competition_state is not None
+    assert agents[0].competition_state.relative_improvement_units == 1
+    assert agents[0].competition_state.time_multiplier == 1
+    assert agents[0].competition_state.status == "baseline"
+    assert agents[0].competition_state.set_id == SET_ID
+
+    agent_detail = await get_latest_public_agent_for_miner_hotkey("eligible-second-hotkey")
+    assert agent_detail is not None
+    assert isinstance(agent_detail, PublicAgent)
+    assert agent_detail.competition_state is not None
+    assert agent_detail.competition_state.relative_improvement_units == 1
+    assert agent_detail.competition_state.time_multiplier == 1
+    assert agent_detail.competition_state.status == "baseline"
+    assert agent_detail.competition_state.set_id == SET_ID
+    assert agent_detail.competition_state == agents[0].competition_state
+
+    core_agent = await get_latest_agent_for_miner_hotkey("eligible-second-hotkey")
+    assert core_agent is not None
+    assert type(core_agent) is Agent
+    assert "competition_state" not in core_agent.model_dump()
+    assert "approved" not in core_agent.model_dump()
 
     await unban_coldkey("banned-leader-coldkey")
     assert [agent.miner_hotkey for agent in await get_top_agents()] == [
         "banned-leader-hotkey",
         "eligible-second-hotkey",
     ]
+
+
+@pytest.mark.anyio
+async def test_top_agents_excludes_review_rejected_agent_with_approval_snapshot():
+    now = datetime.now(timezone.utc)
+    async with _db.pool.acquire() as conn:
+        await _insert_eval_set(conn)
+        rejected_id = await _insert_scored_agent(
+            conn,
+            miner_hotkey="rejected-hotkey",
+            final_score=0.50,
+            cost_usd=0.10,
+            approved=True,
+            approved_at=now - timedelta(hours=1),
+            created_at=SET_CREATED_AT + timedelta(hours=1),
+        )
+        eligible_id = await _insert_scored_agent(
+            conn,
+            miner_hotkey="eligible-hotkey",
+            final_score=0.49,
+            cost_usd=0.10,
+            approved=False,
+            created_at=SET_CREATED_AT + timedelta(hours=2),
+        )
+        await conn.execute(
+            """
+            INSERT INTO agent_approval_states (
+                agent_id, set_id, processing_status, system_verdict, published_verdict
+            ) VALUES ($1, $2, 'completed', 'rejected', 'rejected')
+            """,
+            rejected_id,
+            SET_ID,
+        )
+
+    agents = await get_top_agents()
+
+    assert [agent.agent_id for agent in agents] == [eligible_id]
 
 
 @pytest.mark.anyio

--- a/tests/test_agent_models.py
+++ b/tests/test_agent_models.py
@@ -1,0 +1,317 @@
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from models.agent import (
+    Agent,
+    AgentCompetitionStatus,
+    AgentStatus,
+    ApprovalReviewStatus,
+    PublicAgent,
+    build_agent_competition_state,
+    derive_agent_competition_status,
+)
+
+
+@pytest.mark.parametrize("status", [status for status in AgentStatus if status is not AgentStatus.finished])
+def test_non_finished_competition_status_matches_pipeline_status(status: AgentStatus):
+    assert (
+        derive_agent_competition_status(
+            status=status,
+            set_id=24,
+            approved=True,
+            approval_review_status=ApprovalReviewStatus.rejected,
+        ).value
+        == status.value
+    )
+
+
+def test_competition_status_enum_contains_every_pipeline_status():
+    assert {status.value for status in AgentStatus} <= {status.value for status in AgentCompetitionStatus}
+
+
+def test_core_agent_does_not_expose_competition_payload():
+    agent = Agent(
+        agent_id=uuid4(),
+        miner_hotkey="miner-hotkey",
+        name="Agent",
+        version_num=1,
+        status=AgentStatus.screening_1,
+        created_at=datetime.now(timezone.utc),
+    )
+
+    assert {
+        "set_id",
+        "approved",
+        "performance_delta",
+        "cost_delta",
+        "relative_improvement_units",
+        "time_multiplier",
+        "initial_reward_score",
+        "approved_at",
+        "baseline_agent_id",
+        "baseline_agent_name",
+        "baseline_agent_version_num",
+        "competition_state",
+    }.isdisjoint(agent.model_dump())
+
+
+def test_rejection_takes_precedence_over_published_approval():
+    assert (
+        derive_agent_competition_status(
+            status=AgentStatus.finished,
+            set_id=24,
+            approved=True,
+            approval_review_status=ApprovalReviewStatus.rejected,
+            relative_improvement_units=1.5,
+        )
+        is AgentCompetitionStatus.rejected
+    )
+    assert (
+        build_agent_competition_state(
+            status=AgentStatus.finished,
+            set_id=24,
+            approved=True,
+            approval_review_status=ApprovalReviewStatus.rejected,
+            relative_improvement_units=1.5,
+        ).approved
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    "review_status",
+    [
+        ApprovalReviewStatus.pending,
+        ApprovalReviewStatus.processing,
+        ApprovalReviewStatus.under_review,
+    ],
+)
+def test_published_approval_remains_effective_during_in_progress_review(review_status):
+    state = build_agent_competition_state(
+        status=AgentStatus.finished,
+        set_id=24,
+        approved=True,
+        approval_review_status=review_status,
+        relative_improvement_units=1.5,
+    )
+
+    assert state.status is AgentCompetitionStatus.baseline
+    assert state.approved is True
+
+
+@pytest.mark.parametrize(
+    "review_status",
+    [
+        ApprovalReviewStatus.pending,
+        ApprovalReviewStatus.processing,
+        ApprovalReviewStatus.under_review,
+    ],
+)
+def test_in_progress_review_without_published_approval_is_under_review(review_status):
+    state = build_agent_competition_state(
+        status=AgentStatus.finished,
+        set_id=24,
+        approved=False,
+        approval_review_status=review_status,
+    )
+
+    assert state.status is AgentCompetitionStatus.under_review
+    assert state.approved is False
+
+
+def test_finished_approved_agent_is_identified_as_baseline_only_with_baseline_shape():
+    assert (
+        derive_agent_competition_status(
+            status=AgentStatus.finished,
+            set_id=24,
+            approved=True,
+            relative_improvement_units=1.5,
+        )
+        is AgentCompetitionStatus.baseline
+    )
+    assert (
+        derive_agent_competition_status(
+            status=AgentStatus.finished,
+            set_id=24,
+            approved=True,
+            performance_delta=0.1,
+            relative_improvement_units=1.5,
+        )
+        is AgentCompetitionStatus.approved
+    )
+    assert (
+        derive_agent_competition_status(
+            status=AgentStatus.finished,
+            set_id=24,
+            approved=True,
+        )
+        is AgentCompetitionStatus.approved
+    )
+
+
+def test_approved_review_is_authoritative_if_approval_projection_lags():
+    assert (
+        derive_agent_competition_status(
+            status=AgentStatus.finished,
+            set_id=24,
+            approved=False,
+            approval_review_status=ApprovalReviewStatus.approved,
+        )
+        is AgentCompetitionStatus.approved
+    )
+    assert (
+        build_agent_competition_state(
+            status=AgentStatus.finished,
+            set_id=24,
+            approved=False,
+            approval_review_status=ApprovalReviewStatus.approved,
+        ).approved
+        is True
+    )
+
+
+def test_finished_without_competition_context_is_not_mislabeled():
+    assert (
+        derive_agent_competition_status(status=AgentStatus.finished, approved=False) is AgentCompetitionStatus.finished
+    )
+    assert derive_agent_competition_status(status=AgentStatus.finished, set_id=24) is AgentCompetitionStatus.finished
+    assert (
+        derive_agent_competition_status(status=AgentStatus.finished, set_id=24, approved=False)
+        is AgentCompetitionStatus.didnt_qualify
+    )
+
+
+def test_public_agent_populates_complete_competition_state():
+    baseline_id = uuid4()
+    approved_at = datetime.now(timezone.utc)
+    agent = PublicAgent(
+        agent_id=uuid4(),
+        miner_hotkey="miner-hotkey",
+        name="Agent",
+        version_num=3,
+        status=AgentStatus.finished,
+        created_at=datetime.now(timezone.utc),
+        set_id=24,
+        approved=True,
+        approval_review_status=ApprovalReviewStatus.approved,
+        performance_delta=0.12,
+        cost_delta=0.08,
+        relative_improvement_units=1.6,
+        time_multiplier=1.2,
+        initial_reward_score=1.92,
+        approved_at=approved_at,
+        baseline_agent_id=baseline_id,
+        baseline_agent_name="Baseline",
+        baseline_agent_version_num=2,
+        rank=2,
+        final_score=0.5,
+        validator_count=3,
+        validator_hotkeys=["validator-a", "validator-b", "validator-c"],
+        average_cost_usd=0.03,
+        average_runtime_seconds=12.5,
+        disqualified=False,
+        emission=0.25,
+        reward_weight=0.75,
+    )
+
+    assert agent.competition_state is not None
+    assert agent.competition_state.status is AgentCompetitionStatus.approved
+    assert agent.competition_state.approved is True
+    assert agent.competition_state.set_id == 24
+    assert agent.competition_state.approved_at == approved_at
+    assert agent.competition_state.baseline_agent_id == baseline_id
+    assert agent.competition_state.baseline_agent_name == "Baseline"
+    assert agent.competition_state.baseline_agent_version_num == 2
+    assert agent.competition_state.rank == 2
+    assert agent.competition_state.final_score == 0.5
+    assert agent.emission == 0.25
+    assert agent.reward_weight == 0.75
+    assert agent.status is AgentStatus.finished
+    serialized = agent.model_dump()
+    assert serialized["id"] == agent.agent_id
+    assert serialized["set_id"] == 24
+    assert serialized["approved"] is True
+    assert serialized["approval_review_status"] is ApprovalReviewStatus.approved
+    assert serialized["rank"] == 2
+    assert serialized["final_score"] == 0.5
+    assert serialized["validator_count"] == 3
+    assert serialized["validator_hotkeys"] == ["validator-a", "validator-b", "validator-c"]
+    assert serialized["average_cost_usd"] == 0.03
+    assert serialized["average_runtime_seconds"] == 12.5
+    assert serialized["disqualified"] is False
+    assert serialized["performance_delta"] == 0.12
+    assert serialized["cost_delta"] == 0.08
+    assert serialized["relative_improvement_units"] == 1.6
+    assert serialized["time_multiplier"] == 1.2
+    assert serialized["initial_reward_score"] == 1.92
+    assert serialized["approved_at"] == approved_at
+    assert serialized["baseline_agent_id"] == baseline_id
+    assert serialized["baseline_agent_name"] == "Baseline"
+    assert serialized["baseline_agent_version_num"] == 2
+    assert set(serialized) == {
+        "agent_id",
+        "miner_hotkey",
+        "name",
+        "version_num",
+        "status",
+        "created_at",
+        "emission",
+        "reward_weight",
+        "competition_state",
+        "id",
+        "set_id",
+        "approved",
+        "approval_review_status",
+        "rank",
+        "final_score",
+        "validator_count",
+        "validator_hotkeys",
+        "average_cost_usd",
+        "average_runtime_seconds",
+        "disqualified",
+        "approved_at",
+        "performance_delta",
+        "cost_delta",
+        "relative_improvement_units",
+        "time_multiplier",
+        "initial_reward_score",
+        "baseline_agent_id",
+        "baseline_agent_name",
+        "baseline_agent_version_num",
+    }
+
+
+def test_public_agent_recomputes_supplied_competition_state():
+    agent = PublicAgent(
+        agent_id=uuid4(),
+        miner_hotkey="miner-hotkey",
+        name="Agent",
+        version_num=1,
+        status=AgentStatus.evaluating,
+        created_at=datetime.now(timezone.utc),
+        set_id=24,
+        approved=True,
+        competition_state={"status": "approved", "approved": True},
+    )
+
+    assert agent.competition_state.status is AgentCompetitionStatus.evaluating
+    assert agent.competition_state.approved is False
+
+
+def test_public_agent_without_competition_context_has_null_state():
+    agent = PublicAgent(
+        agent_id=uuid4(),
+        miner_hotkey="miner-hotkey",
+        name="Agent",
+        version_num=1,
+        status=AgentStatus.screening_1,
+        created_at=datetime.now(timezone.utc),
+    )
+
+    assert agent.competition_state is None
+    assert agent.id == agent.agent_id
+    assert agent.set_id is None
+    assert agent.approved is None
+    assert agent.final_score is None


### PR DESCRIPTION
- Unifies all FE agent responses under `PublicAgent` with `competition_state`
- Keeps temporary aliases for backwards compatibility
- Removes the unused public benchmark-agent endpoint while retaining internal exclusion
- Adds `total_agents` top funnel at the dashboard page