### PR TITLE
chore: Harden Ridges k8s lifecycle without switching to Harbor's environment

### DIFF
--- a/ridges_harbor/k8s_environment.py
+++ b/ridges_harbor/k8s_environment.py
@@ -23,12 +23,14 @@ Two classes are defined here:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import io
 import logging
 import re
 import shlex
 import ssl
 import tarfile
+import time
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -54,6 +56,61 @@ BUILD_MEMORY_TIERS: list[tuple[str, str]] = [
     ("16Gi", "28Gi"),  # fits ccx33 (32GB) evaluator nodes
 ]
 BUILD_MEMORY_TIER_ANNOTATION = "ridges.ai/build-memory-tier"
+
+# RFC-1123 labels: lowercase alphanumerics and ``-``, at most 63 characters,
+# starting and ending with an alphanumeric. Pod names and label values both
+# have to satisfy this.
+_KUBERNETES_NAME_MAX_LENGTH = 63
+_KUBERNETES_NAME_ILLEGAL_RE = re.compile(r"[^a-z0-9]+")
+
+#: How often to ping an otherwise-silent exec stream to keep intermediaries
+#: from reaping it as idle.
+_KUBERNETES_EXEC_STREAM_PING_INTERVAL_SEC = 30.0
+
+_FATAL_WAITING_REASONS = frozenset({"ImagePullBackOff", "ErrImagePull", "CrashLoopBackOff"})
+
+
+def sanitize_kubernetes_resource_name(name: str) -> str:
+    """Coerce *name* into an RFC-1123 label the API server accepts.
+
+    Over-long names keep a hash suffix so that two names sharing a 63-char
+    prefix stay distinct instead of colliding on the same pod.
+    """
+    sanitized = _KUBERNETES_NAME_ILLEGAL_RE.sub("-", name.lower()).strip("-")
+    if not sanitized:
+        return "ridges"
+    if len(sanitized) <= _KUBERNETES_NAME_MAX_LENGTH:
+        return sanitized
+
+    digest = hashlib.sha256(name.encode()).hexdigest()[:8]
+    prefix_length = _KUBERNETES_NAME_MAX_LENGTH - len(digest) - 1
+    prefix = sanitized[:prefix_length].rstrip("-")
+    return f"{prefix}-{digest}"
+
+
+def build_isolated_k8s_apis(
+    kubeconfig_context: str | None = None,
+) -> tuple["k8s_client.CoreV1Api", "k8s_client.BatchV1Api"]:
+    """Return Core and Batch clients that share one non-global ApiClient.
+
+    Credentials land in a fresh ``Configuration`` instead of the SDK's global
+    default, so concurrent trials cannot observe a half-written kubeconfig.
+    Each environment also needs its own ``ApiClient``: the kubernetes
+    ``stream()`` helper monkey-patches ``ApiClient.request`` for the duration
+    of an exec websocket, which corrupts concurrent REST calls issued through
+    a shared client.
+    """
+    configuration = k8s_client.Configuration()
+    try:
+        k8s_config.load_incluster_config(client_configuration=configuration)
+    except k8s_config.ConfigException:
+        k8s_config.load_kube_config(
+            context=kubeconfig_context,
+            client_configuration=configuration,
+        )
+    api_client = k8s_client.ApiClient(configuration)
+    return k8s_client.CoreV1Api(api_client), k8s_client.BatchV1Api(api_client)
+
 
 # ---------------------------------------------------------------------------
 # KubernetesEnvironment – generic base
@@ -119,12 +176,14 @@ class KubernetesEnvironment(BaseEnvironment):
         else:
             self.memory_limit = None
 
-        # Pod name: lowercase, no underscores, max 63 chars
-        self.pod_name = session_id.lower().replace("_", "-")[:63]
+        # Pod name: RFC-1123 label, hash-suffixed when over 63 chars.
+        self.pod_name = sanitize_kubernetes_resource_name(session_id)
 
-        # Kubernetes client – lazily initialised
+        # Kubernetes client – lazily initialised. Core and Batch share one
+        # isolated ApiClient so exec stream() cannot corrupt sibling REST calls.
         self._core_api: k8s_client.CoreV1Api | None = None
         self._batch_api: k8s_client.BatchV1Api | None = None
+        self._api_client: Any | None = None
 
     # ------------------------------------------------------------------
     # BaseEnvironment abstract properties
@@ -159,17 +218,25 @@ class KubernetesEnvironment(BaseEnvironment):
         """No local file validation needed – the image lives in the registry."""
 
     def _init_k8s_client(self) -> None:
-        """Load kubeconfig (or in-cluster config) and create API clients."""
-        try:
-            k8s_config.load_incluster_config()
-        except k8s_config.ConfigException:
-            k8s_config.load_kube_config(context=self.kubeconfig_context)
-        self._core_api = k8s_client.CoreV1Api()
-        self._batch_api = k8s_client.BatchV1Api()
+        """Load kubeconfig (or in-cluster config) into an isolated ApiClient."""
+        self._core_api, self._batch_api = build_isolated_k8s_apis(self.kubeconfig_context)
+        self._api_client = self._core_api.api_client
 
     async def _ensure_client(self) -> None:
         if self._core_api is None:
             await asyncio.to_thread(self._init_k8s_client)
+
+    def _release_client(self) -> None:
+        api_client = self._api_client
+        self._core_api = None
+        self._batch_api = None
+        self._api_client = None
+        if api_client is None:
+            return
+        try:
+            api_client.close()
+        except Exception:
+            pass
 
     @property
     def _api(self) -> k8s_client.CoreV1Api:
@@ -190,7 +257,7 @@ class KubernetesEnvironment(BaseEnvironment):
     def _build_labels(self) -> dict[str, str]:
         base = {
             "app": "ridges-eval",
-            "session": self.session_id[:63],
+            "session": sanitize_kubernetes_resource_name(self.session_id),
         }
         base.update(self._extra_labels)
         return base
@@ -302,14 +369,17 @@ class KubernetesEnvironment(BaseEnvironment):
             )
 
     async def stop(self, delete: bool = True) -> None:
-        """Delete the Pod (optionally)."""
+        """Delete the Pod (optionally) and release the isolated API client."""
         if self._core_api is None:
             return
-        if delete:
-            try:
-                await self._delete_pod_and_wait()
-            except RuntimeError:
-                self.logger.warning(f"Pod {self.pod_name} did not terminate cleanly during stop()")
+        try:
+            if delete:
+                try:
+                    await self._delete_pod_and_wait()
+                except RuntimeError:
+                    self.logger.warning(f"Pod {self.pod_name} did not terminate cleanly during stop()")
+        finally:
+            self._release_client()
 
     async def exec(
         self,
@@ -376,14 +446,7 @@ class KubernetesEnvironment(BaseEnvironment):
                 stdout, stderr = await asyncio.to_thread(self._read_exec_output, resp)
 
             resp.run_forever(timeout=0)
-            try:
-                return_code = resp.returncode
-            except (TypeError, ValueError, KeyError, IndexError) as exc:
-                raise ExecTransportError(
-                    f"Exec stream to Pod {self.pod_name} returned a malformed exit status: {exc!r}"
-                ) from exc
-            if return_code is None:
-                raise ExecTransportError(f"Exec stream to Pod {self.pod_name} closed without an exit status")
+            return_code = self._exec_stream_return_code(resp)
             return ExecResult(stdout=stdout, stderr=stderr, return_code=return_code)
 
         except ExecTransportError:
@@ -535,21 +598,55 @@ class KubernetesEnvironment(BaseEnvironment):
     # runs.
     # ------------------------------------------------------------------
 
+    def _exec_stream_return_code(self, resp: Any) -> int:
+        """The command's exit status, or raise if the stream never delivered one."""
+        try:
+            return_code = resp.returncode
+        except (TypeError, ValueError, KeyError, IndexError) as exc:
+            raise ExecTransportError(
+                f"Exec stream to Pod {self.pod_name} returned a malformed exit status: {exc!r}"
+            ) from exc
+        if return_code is None:
+            raise ExecTransportError(f"Exec stream to Pod {self.pod_name} closed without an exit status")
+        return return_code
+
+    def _ping_exec_stream(self, resp: Any) -> None:
+        """Best-effort websocket ping; raise only if the command has no exit status yet."""
+        sock = getattr(resp, "sock", None)
+        ping = getattr(sock, "ping", None)
+        if ping is None:
+            return
+        try:
+            ping()
+        except Exception as exc:
+            try:
+                self._exec_stream_return_code(resp)
+            except ExecTransportError:
+                raise ExecTransportError(
+                    f"Kubernetes exec stream keepalive ping failed for Pod {self.pod_name}"
+                ) from exc
+
     def _read_exec_output(self, resp: Any) -> tuple[str, str]:
         stdout = ""
         stderr = ""
+        last_ping = time.monotonic()
         while resp.is_open():
             resp.update(timeout=1)
             if resp.peek_stdout():
                 stdout += resp.read_stdout()
             if resp.peek_stderr():
                 stderr += resp.read_stderr()
+            now = time.monotonic()
+            if now - last_ping >= _KUBERNETES_EXEC_STREAM_PING_INTERVAL_SEC and resp.is_open():
+                self._ping_exec_stream(resp)
+                last_ping = now
         return stdout, stderr
 
     def _read_tar_stream(self, resp: Any) -> tuple[bytes, str]:
         """Blocking: drain a WebSocket exec stream, returning (stdout_bytes, stderr_text)."""
         tar_data = b""
         stderr_data = ""
+        last_ping = time.monotonic()
         while resp.is_open():
             resp.update(timeout=1)
             if resp.peek_stdout():
@@ -557,6 +654,10 @@ class KubernetesEnvironment(BaseEnvironment):
                 tar_data += chunk.encode("utf-8", errors="surrogateescape") if isinstance(chunk, str) else chunk
             if resp.peek_stderr():
                 stderr_data += resp.read_stderr()
+            now = time.monotonic()
+            if now - last_ping >= _KUBERNETES_EXEC_STREAM_PING_INTERVAL_SEC and resp.is_open():
+                self._ping_exec_stream(resp)
+                last_ping = now
         return tar_data, stderr_data
 
     def _write_tar_stream(self, resp: Any, payload: bytes) -> None:
@@ -597,8 +698,63 @@ class KubernetesEnvironment(BaseEnvironment):
         with tarfile.open(fileobj=tar_buffer, mode="r") as tar:
             tar.extractall(path=str(target_dir), filter="data")
 
+    @staticmethod
+    def _iter_container_statuses(pod: Any) -> list[tuple[str, Any]]:
+        status = pod.status
+        if status is None:
+            return []
+        items: list[tuple[str, Any]] = [("container", cs) for cs in (status.container_statuses or [])]
+        items.extend(("init container", cs) for cs in (status.init_container_statuses or []))
+        return items
+
+    def _raise_if_fatal_container_wait(self, kind: str, cs: Any) -> None:
+        waiting = cs.state.waiting if cs.state else None
+        if waiting is None or waiting.reason not in _FATAL_WAITING_REASONS:
+            return
+        name = getattr(cs, "name", "unknown")
+        message = waiting.message or waiting.reason
+        if waiting.reason in ("ImagePullBackOff", "ErrImagePull"):
+            raise RuntimeError(f"Failed to pull image for {kind} {name!r} in Pod {self.pod_name}: {message}")
+        raise RuntimeError(f"{kind.title()} {name!r} in Pod {self.pod_name} failed during startup: {message}")
+
+    async def _check_regular_containers_execable(self) -> None:
+        """Raise if the pod or a regular container can no longer accept exec.
+
+        One-shot init containers (iptables-init) terminate with exit 0 before
+        the pod is Running; that is success, not a dead sandbox.
+        """
+        try:
+            pod = await asyncio.to_thread(
+                self._api.read_namespaced_pod,
+                name=self.pod_name,
+                namespace=self.namespace,
+            )
+        except ApiException:
+            return
+
+        phase = pod.status.phase if pod.status else None
+        if phase in ("Failed", "Succeeded"):
+            raise RuntimeError(f"Pod {self.pod_name} is in terminal phase '{phase}' and cannot accept exec.")
+
+        for kind, cs in self._iter_container_statuses(pod):
+            if kind == "init container":
+                continue
+            terminated = None
+            if cs.state and cs.state.terminated:
+                terminated = cs.state.terminated
+            elif cs.last_state and cs.last_state.terminated:
+                terminated = cs.last_state.terminated
+            if terminated is not None:
+                raise RuntimeError(
+                    f"Container {cs.name!r} in pod {self.pod_name} has terminated "
+                    f"(reason={terminated.reason or ''!r}, "
+                    f"exit_code={terminated.exit_code}). "
+                    "Cannot exec into dead container."
+                )
+
     async def _wait_for_container_exec_ready(self, max_attempts: int = 60) -> None:
         for attempt in range(max_attempts):
+            await self._check_regular_containers_execable()
             try:
                 resp = await asyncio.to_thread(
                     stream,
@@ -639,18 +795,20 @@ class KubernetesEnvironment(BaseEnvironment):
                     namespace=self.namespace,
                 )
                 phase = pod.status.phase
+                for kind, cs in self._iter_container_statuses(pod):
+                    self._raise_if_fatal_container_wait(kind, cs)
+                    if kind == "init container" and cs.state and cs.state.terminated:
+                        exit_code = cs.state.terminated.exit_code
+                        if exit_code not in (0, None):
+                            raise RuntimeError(
+                                f"Init container {cs.name!r} in Pod {self.pod_name} exited with code {exit_code}"
+                            )
                 if phase == "Running" and pod.status.container_statuses:
                     if all(c.ready for c in pod.status.container_statuses):
                         self.logger.debug(f"Pod {self.pod_name} is ready")
                         return
                 elif phase in ("Failed", "Unknown", "Error"):
                     raise RuntimeError(f"Pod {self.pod_name} failed to start: {self._pod_failure_summary(pod)}")
-                elif phase == "Pending" and pod.status.container_statuses:
-                    for cs in pod.status.container_statuses:
-                        if cs.state.waiting and cs.state.waiting.reason in ("ImagePullBackOff", "ErrImagePull"):
-                            raise RuntimeError(
-                                f"Failed to pull image for Pod {self.pod_name}: {cs.state.waiting.message}"
-                            )
             except ApiException as exc:
                 if exc.status != 404:
                     raise RuntimeError(f"Kubernetes API error while waiting for Pod: {exc}") from exc
@@ -696,6 +854,12 @@ class KubernetesEnvironment(BaseEnvironment):
                     parts.append(f"container {cs.name} waiting: {cs.state.waiting.reason}")
                 elif cs.state.terminated:
                     parts.append(f"container {cs.name} terminated: exit={cs.state.terminated.exit_code}")
+        if pod.status.init_container_statuses:
+            for cs in pod.status.init_container_statuses:
+                if cs.state.waiting:
+                    parts.append(f"init container {cs.name} waiting: {cs.state.waiting.reason}")
+                elif cs.state.terminated:
+                    parts.append(f"init container {cs.name} terminated: exit={cs.state.terminated.exit_code}")
         return "; ".join(parts) or "unknown"
 
 
@@ -1458,18 +1622,6 @@ def _build_job_body(
     )
 
 
-def _init_standalone_k8s_clients(
-    kubeconfig_context: str | None,
-) -> tuple["k8s_client.CoreV1Api", "k8s_client.BatchV1Api"]:
-    """Load kubeconfig (or in-cluster config) and create API clients, outside
-    the context of any particular Harbor environment instance."""
-    try:
-        k8s_config.load_incluster_config()
-    except k8s_config.ConfigException:
-        k8s_config.load_kube_config(context=kubeconfig_context)
-    return k8s_client.CoreV1Api(), k8s_client.BatchV1Api()
-
-
 async def pre_build_images(
     tasks: Sequence[tuple[str, str, str]],
     *,
@@ -1519,7 +1671,7 @@ async def pre_build_images(
         build_registry_insecure if build_registry_insecure is not None else registry_insecure
     )
 
-    core_api, batch_api = await asyncio.to_thread(_init_standalone_k8s_clients, kubeconfig_context)
+    core_api, batch_api = await asyncio.to_thread(build_isolated_k8s_apis, kubeconfig_context)
 
     async def _pre_build_one(task_name: str, digest_tag: str, presigned_url: str) -> None:
         image_ref = f"{effective_build_registry}/{task_name.lower()}:{digest_tag}"

--- a/ridges_harbor/k8s_runtime.py
+++ b/ridges_harbor/k8s_runtime.py
@@ -15,6 +15,8 @@ from typing import Any, Awaitable, Callable
 
 from kubernetes import client as k8s_client
 
+from ridges_harbor.k8s_environment import sanitize_kubernetes_resource_name
+
 logger = logging.getLogger(__name__)
 
 TrialHook = Callable[[Any], Awaitable[None]]
@@ -43,7 +45,7 @@ def build_k8s_verifier_egress_hook(
     """
 
     async def enable_verifier_egress(event: Any) -> None:
-        pod_name = event.trial_id.lower().replace("_", "-")[:63]
+        pod_name = sanitize_kubernetes_resource_name(event.trial_id)
 
         # 1. Flip the NetworkPolicy label.
         await asyncio.to_thread(

--- a/ridges_harbor/runner.py
+++ b/ridges_harbor/runner.py
@@ -183,9 +183,8 @@ async def _run_task_dir(
         # The proxy sidecar shares the pod network namespace and listens on 8080.
         agent_env["SANDBOX_PROXY_URL"] = "http://127.0.0.1:8080"
 
-        from kubernetes import client as k8s_client_mod
-        from kubernetes import config as k8s_config_mod
-
+        from ridges_harbor.k8s_environment import build_isolated_k8s_apis
+        from ridges_harbor.k8s_runtime import build_k8s_verifier_egress_hook
         from validator.config import (
             K8S_BUILD_REGISTRY,
             K8S_BUILD_REGISTRY_INSECURE,
@@ -204,8 +203,6 @@ async def _run_task_dir(
 
         K8S_OWNER_POD_NAME = os.getenv("MY_POD_NAME")
         K8S_OWNER_POD_UID = os.getenv("MY_POD_UID")
-
-        from ridges_harbor.k8s_runtime import build_k8s_verifier_egress_hook
 
         digest_tag = task_digest.split(":")[1][:12]
 
@@ -245,12 +242,7 @@ async def _run_task_dir(
             },
         )
 
-        # Build k8s client for the egress hook
-        try:
-            k8s_config_mod.load_incluster_config()
-        except k8s_config_mod.ConfigException:
-            k8s_config_mod.load_kube_config(context=K8S_CONTEXT)
-        core_api = k8s_client_mod.CoreV1Api()
+        core_api, _batch_api = build_isolated_k8s_apis(K8S_CONTEXT)
 
         enable_verifier_egress = build_k8s_verifier_egress_hook(
             namespace=K8S_NAMESPACE,

--- a/tests/ridges_harbor/conftest.py
+++ b/tests/ridges_harbor/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def anyio_backend() -> str:
+    return "asyncio"

--- a/tests/ridges_harbor/test_exec_transport.py
+++ b/tests/ridges_harbor/test_exec_transport.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from kubernetes.client.rest import ApiException
@@ -162,6 +163,59 @@ async def test_statusful_api_error_still_returns_exec_result(monkeypatch) -> Non
 
     assert result.return_code == 1
     assert "API error (500)" in result.stderr
+
+
+def test_read_exec_output_pings_after_idle_interval(monkeypatch) -> None:
+    clock = {"t": 0.0}
+
+    class SilentResp(FakeResp):
+        def __init__(self):
+            super().__init__(returncode=0)
+            self._open = True
+            self._updates = 0
+            self.sock = MagicMock()
+
+        def is_open(self):
+            return self._open
+
+        def peek_stdout(self):
+            return False
+
+        def update(self, timeout):
+            self._updates += 1
+            clock["t"] += 31.0
+            if self._updates >= 2:
+                self._open = False
+
+    monkeypatch.setattr(k8s_environment.time, "monotonic", lambda: clock["t"])
+    resp = SilentResp()
+
+    make_env()._read_exec_output(resp)
+
+    resp.sock.ping.assert_called()
+
+
+def test_keepalive_ping_failure_is_ignored_when_command_already_finished() -> None:
+    class FinishedResp(FakeResp):
+        def __init__(self):
+            super().__init__(returncode=0)
+            self.sock = MagicMock()
+            self.sock.ping.side_effect = OSError("closed")
+
+    env = make_env()
+    env._ping_exec_stream(FinishedResp())
+
+
+def test_keepalive_ping_failure_raises_when_stream_has_no_status() -> None:
+    class DeadResp(FakeResp):
+        def __init__(self):
+            super().__init__(returncode=None)
+            self.sock = MagicMock()
+            self.sock.ping.side_effect = OSError("closed")
+
+    env = make_env()
+    with pytest.raises(ExecTransportError, match="keepalive ping failed"):
+        env._ping_exec_stream(DeadResp())
 
 
 def make_agent(tmp_path: Path) -> RidgesMinerAgent:

--- a/tests/ridges_harbor/test_k8s_client.py
+++ b/tests/ridges_harbor/test_k8s_client.py
@@ -1,0 +1,58 @@
+from kubernetes import client as k8s_client
+from kubernetes import config as k8s_config
+
+from ridges_harbor.k8s_environment import build_isolated_k8s_apis
+
+
+def test_isolated_apis_use_fresh_configuration_and_api_client(monkeypatch) -> None:
+    configurations: list[k8s_client.Configuration] = []
+
+    def fake_incluster(client_configuration=None) -> None:
+        configurations.append(client_configuration)
+        client_configuration.host = "https://kubernetes.example.test"
+
+    monkeypatch.setattr(
+        "ridges_harbor.k8s_environment.k8s_config.load_incluster_config",
+        fake_incluster,
+    )
+
+    core1, batch1 = build_isolated_k8s_apis()
+    core2, batch2 = build_isolated_k8s_apis()
+    try:
+        assert core1 is not core2
+        assert core1.api_client is not core2.api_client
+        assert core1.api_client is batch1.api_client
+        assert core2.api_client is batch2.api_client
+        assert configurations[0] is not configurations[1]
+        assert core1.api_client.configuration is configurations[0]
+        assert core2.api_client.configuration is configurations[1]
+    finally:
+        core1.api_client.close()
+        core2.api_client.close()
+
+
+def test_isolated_apis_fall_back_to_kubeconfig(monkeypatch) -> None:
+    def fake_incluster(client_configuration=None) -> None:
+        raise k8s_config.ConfigException("no service account")
+
+    kube_configs: list[k8s_client.Configuration] = []
+
+    def fake_kubeconfig(*, context=None, client_configuration=None) -> None:
+        kube_configs.append(client_configuration)
+        client_configuration.host = "https://kubeconfig.example.test"
+
+    monkeypatch.setattr(
+        "ridges_harbor.k8s_environment.k8s_config.load_incluster_config",
+        fake_incluster,
+    )
+    monkeypatch.setattr(
+        "ridges_harbor.k8s_environment.k8s_config.load_kube_config",
+        fake_kubeconfig,
+    )
+
+    core, batch = build_isolated_k8s_apis("my-context")
+    try:
+        assert kube_configs[0] is core.api_client.configuration
+        assert core.api_client is batch.api_client
+    finally:
+        core.api_client.close()

--- a/tests/ridges_harbor/test_k8s_names.py
+++ b/tests/ridges_harbor/test_k8s_names.py
@@ -1,0 +1,39 @@
+import re
+
+import pytest
+
+from ridges_harbor.k8s_environment import sanitize_kubernetes_resource_name
+
+
+def test_short_names_pass_through() -> None:
+    assert sanitize_kubernetes_resource_name("my-task-v2-abc123") == "my-task-v2-abc123"
+
+
+def test_long_session_ids_stay_distinct() -> None:
+    long_prefix = "task-" * 20
+    first = sanitize_kubernetes_resource_name(f"{long_prefix}first")
+    second = sanitize_kubernetes_resource_name(f"{long_prefix}second")
+
+    assert first != second
+    assert len(first) <= 63 and len(second) <= 63
+
+
+@pytest.mark.parametrize(
+    "session_id",
+    [
+        "task__abc123",
+        "My_Task/v2__ABC123",
+        "trailing-underscore_",
+        "x" * 80 + "_",
+        "___",
+    ],
+)
+def test_sanitized_names_are_rfc1123(session_id: str) -> None:
+    name = sanitize_kubernetes_resource_name(session_id)
+    assert 0 < len(name) <= 63
+    assert re.fullmatch(r"[a-z0-9]([a-z0-9-]*[a-z0-9])?", name), name
+
+
+def test_empty_illegal_input_falls_back() -> None:
+    assert sanitize_kubernetes_resource_name("___") == "ridges"
+    assert sanitize_kubernetes_resource_name("...") == "ridges"

--- a/tests/ridges_harbor/test_k8s_pod_ready.py
+++ b/tests/ridges_harbor/test_k8s_pod_ready.py
@@ -1,0 +1,114 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from ridges_harbor.k8s_environment import KubernetesEnvironment
+
+
+def _status(*, name: str, waiting=None, terminated=None, last_terminated=None, ready: bool = False):
+    status = MagicMock()
+    status.name = name
+    status.ready = ready
+    status.state = MagicMock(waiting=waiting, terminated=terminated)
+    status.last_state = MagicMock(terminated=last_terminated)
+    return status
+
+
+def _make_env() -> KubernetesEnvironment:
+    env = KubernetesEnvironment.__new__(KubernetesEnvironment)
+    env.pod_name = "test-pod"
+    env.namespace = "ridges"
+    env.logger = MagicMock()
+    env._core_api = MagicMock()
+    return env
+
+
+def _pod(*, phase: str, containers=None, inits=None):
+    pod = MagicMock()
+    pod.status = MagicMock(
+        phase=phase,
+        reason=None,
+        message=None,
+        container_statuses=containers or [],
+        init_container_statuses=inits or [],
+    )
+    return pod
+
+
+@pytest.mark.anyio
+async def test_init_image_pull_failure_fails_fast() -> None:
+    waiting = MagicMock(reason="ImagePullBackOff", message="denied")
+    env = _make_env()
+    env._core_api.read_namespaced_pod.return_value = _pod(
+        phase="Pending",
+        inits=[_status(name="iptables-init", waiting=waiting)],
+    )
+
+    with pytest.raises(RuntimeError, match="init container 'iptables-init'.*denied"):
+        await env._wait_for_pod_ready(timeout_sec=1)
+
+
+@pytest.mark.anyio
+async def test_init_crashloop_fails_fast() -> None:
+    waiting = MagicMock(reason="CrashLoopBackOff", message="back-off")
+    env = _make_env()
+    env._core_api.read_namespaced_pod.return_value = _pod(
+        phase="Pending",
+        inits=[_status(name="iptables-init", waiting=waiting)],
+    )
+
+    with pytest.raises(RuntimeError, match="iptables-init.*back-off"):
+        await env._wait_for_pod_ready(timeout_sec=1)
+
+
+@pytest.mark.anyio
+async def test_init_nonzero_exit_fails_fast() -> None:
+    terminated = MagicMock(exit_code=2, reason="Error")
+    env = _make_env()
+    env._core_api.read_namespaced_pod.return_value = _pod(
+        phase="Pending",
+        inits=[_status(name="iptables-init", terminated=terminated)],
+    )
+
+    with pytest.raises(RuntimeError, match="exited with code 2"):
+        await env._wait_for_pod_ready(timeout_sec=1)
+
+
+@pytest.mark.anyio
+async def test_successful_init_does_not_block_exec_ready() -> None:
+    terminated = MagicMock(exit_code=0, reason="Completed")
+    env = _make_env()
+    env._core_api.read_namespaced_pod.return_value = _pod(
+        phase="Running",
+        containers=[_status(name="main", ready=True), _status(name="proxy", ready=True)],
+        inits=[_status(name="iptables-init", terminated=terminated)],
+    )
+
+    await env._check_regular_containers_execable()
+
+
+@pytest.mark.anyio
+async def test_terminated_main_blocks_exec_ready() -> None:
+    terminated = MagicMock(exit_code=137, reason="OOMKilled")
+    env = _make_env()
+    env._core_api.read_namespaced_pod.return_value = _pod(
+        phase="Running",
+        containers=[_status(name="main", terminated=terminated)],
+        inits=[_status(name="iptables-init", terminated=MagicMock(exit_code=0, reason="Completed"))],
+    )
+
+    with pytest.raises(RuntimeError, match="Container 'main'.*exit_code=137"):
+        await env._check_regular_containers_execable()
+
+
+def test_failure_summary_includes_init_container() -> None:
+    waiting = MagicMock(reason="CrashLoopBackOff")
+    env = _make_env()
+    pod = _pod(
+        phase="Pending",
+        inits=[_status(name="iptables-init", waiting=waiting)],
+    )
+
+    summary = env._pod_failure_summary(pod)
+
+    assert "init container iptables-init waiting: CrashLoopBackOff" in summary

--- a/tests/ridges_harbor/test_k8s_runtime.py
+++ b/tests/ridges_harbor/test_k8s_runtime.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from ridges_harbor.k8s_environment import sanitize_kubernetes_resource_name
+from ridges_harbor.k8s_runtime import build_k8s_verifier_egress_hook
+
+
+class _Event:
+    def __init__(self, trial_id: str) -> None:
+        self.trial_id = trial_id
+
+
+@pytest.mark.anyio
+async def test_verifier_egress_hook_uses_sanitized_trial_id() -> None:
+    trial_id = "My_Task/v2__ABC123"
+    core_api = MagicMock()
+    hook = build_k8s_verifier_egress_hook(namespace="ridges", core_api=core_api)
+
+    await hook(_Event(trial_id))
+
+    expected = sanitize_kubernetes_resource_name(trial_id)
+    core_api.patch_namespaced_pod.assert_called_once()
+    assert core_api.patch_namespaced_pod.call_args.kwargs["name"] == expected
+    assert core_api.patch_namespaced_pod.call_args.kwargs["namespace"] == "ridges"
+
+
+@pytest.mark.anyio
+async def test_verifier_egress_hook_matches_environment_pod_name() -> None:
+    trial_id = ("task-" * 20) + "first"
+    core_api = MagicMock()
+    hook = build_k8s_verifier_egress_hook(namespace="ridges", core_api=core_api)
+
+    await hook(_Event(trial_id))
+
+    patched_name = core_api.patch_namespaced_pod.call_args.kwargs["name"]
+    assert patched_name == sanitize_kubernetes_resource_name(trial_id)
+    assert len(patched_name) <= 63

--- a/tests/ridges_harbor/test_runner.py
+++ b/tests/ridges_harbor/test_runner.py
@@ -267,15 +267,14 @@ async def test_run_task_dir_uses_task_config_and_environment_env(tmp_path: Path,
 
 @pytest.mark.anyio
 async def test_run_task_dir_uses_loopback_proxy_in_kubernetes(tmp_path: Path, monkeypatch) -> None:
-    from kubernetes import client as k8s_client
-    from kubernetes import config as k8s_config
-
     from validator import config as validator_config
 
     _install_fake_harbor(monkeypatch)
     monkeypatch.setenv("RIDGES_ENVIRONMENT_TYPE", "kubernetes")
-    monkeypatch.setattr(k8s_config, "load_incluster_config", lambda: None)
-    monkeypatch.setattr(k8s_client, "CoreV1Api", lambda: object())
+    monkeypatch.setattr(
+        "ridges_harbor.k8s_environment.build_isolated_k8s_apis",
+        lambda context=None: (object(), object()),
+    )
     # These are absent if another test imported validator.config in Docker mode.
     monkeypatch.setattr(validator_config, "K8S_MEMORY_REQUEST_FRACTION", 0.25, raising=False)
     monkeypatch.setattr(validator_config, "K8S_CPU_REQUEST_FRACTION", 0.25, raising=False)


### PR DESCRIPTION
Harbor has a PR opened on vanilla Kubernetes support. I compared it to Ridges’ and kept our own implementation: Harbor cannot run untrusted miner evals as-is (proxy sidecar, iptables intercept, capability drop, in-cluster BuildKit). Switching would not remove our k8s code; it would couple that product logic to Harbor’s private pod builder.

I did take four lifecycle fixes from their PR and ported them into RidgesKubernetesEnvironment:
- Ping idle exec/tar websockets every 30s so long silent agent runs are not dropped
- Give each trial its own ApiClient / Configuration (screeners run many evals in one process)
- RFC-1123 pod names with a hash suffix; the verification egress hook uses the same sanitizer
- Fail fast on init-container ImagePull/CrashLoop; do not treat a successful iptables-init (exit 0) as a dead pod
