### PR TITLE
Feat: Add new fields to competition

### DIFF
--- a/alembic/versions/2026_09_03_add_competition_description_and_links.py
+++ b/alembic/versions/2026_09_03_add_competition_description_and_links.py
@@ -1,4 +1,4 @@
-"""add competition description and links
+"""add competition description, links, and metadata admin events
 
 Revision ID: 4a2c7b91de05
 Revises: 06f4bede4ef6
@@ -16,6 +16,8 @@ revision: str = "4a2c7b91de05"
 down_revision: Union[str, Sequence[str], None] = "06f4bede4ef6"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
+
+_OPERATION_CONSTRAINT = "ck_competition_admin_events_operation"
 
 
 def upgrade() -> None:
@@ -44,8 +46,25 @@ def upgrade() -> None:
         "coalesce(competitions_links_are_nonblank(links), true)",
     )
 
+    # Editorial updates are audited alongside state, policy, and allocation changes.
+    op.drop_constraint(_OPERATION_CONSTRAINT, "competition_admin_events", type_="check")
+    op.create_check_constraint(
+        _OPERATION_CONSTRAINT,
+        "competition_admin_events",
+        "operation IN ('state', 'policy', 'allocation', 'metadata')",
+    )
+
 
 def downgrade() -> None:
+    # Metadata events cannot satisfy the narrower constraint, so drop them first.
+    op.execute("DELETE FROM competition_admin_events WHERE operation = 'metadata'")
+    op.drop_constraint(_OPERATION_CONSTRAINT, "competition_admin_events", type_="check")
+    op.create_check_constraint(
+        _OPERATION_CONSTRAINT,
+        "competition_admin_events",
+        "operation IN ('state', 'policy', 'allocation')",
+    )
+
     op.drop_constraint("ck_competitions_links_nonblank", "competitions", type_="check")
     op.execute("DROP FUNCTION IF EXISTS competitions_links_are_nonblank(text[])")
     op.drop_column("competitions", "links")

--- a/alembic/versions/2026_09_03_add_competition_description_and_links.py
+++ b/alembic/versions/2026_09_03_add_competition_description_and_links.py
@@ -1,0 +1,52 @@
+"""add competition description and links
+
+Revision ID: 4a2c7b91de05
+Revises: 06f4bede4ef6
+Create Date: 2026-09-03 10:12:44.201883
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "4a2c7b91de05"
+down_revision: Union[str, Sequence[str], None] = "06f4bede4ef6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("competitions", sa.Column("description", sa.Text(), nullable=True))
+    op.add_column(
+        "competitions",
+        sa.Column(
+            "links",
+            postgresql.ARRAY(sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::text[]"),
+        ),
+    )
+    op.execute(
+        """
+        CREATE FUNCTION competitions_links_are_nonblank(links text[]) RETURNS boolean
+        LANGUAGE sql IMMUTABLE AS $$
+            SELECT bool_and(link IS NOT NULL AND btrim(link, E' \\t\\n\\r') <> '')
+            FROM unnest(links) AS link
+        $$
+        """
+    )
+    op.create_check_constraint(
+        "ck_competitions_links_nonblank",
+        "competitions",
+        "coalesce(competitions_links_are_nonblank(links), true)",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_competitions_links_nonblank", "competitions", type_="check")
+    op.execute("DROP FUNCTION IF EXISTS competitions_links_are_nonblank(text[])")
+    op.drop_column("competitions", "links")
+    op.drop_column("competitions", "description")

--- a/api/endpoints/admin.py
+++ b/api/endpoints/admin.py
@@ -14,6 +14,7 @@ from models.competition import (
     CompetitionAdminSnapshot,
     CompetitionAllocationSnapshot,
     CompetitionAllocationUpdateRequest,
+    CompetitionMetadataUpdateRequest,
     CompetitionPolicyUpdateRequest,
     CompetitionStateUpdateRequest,
 )
@@ -21,6 +22,7 @@ from models.upload_credit import UploadCredit
 from queries.banned_coldkey import ban_coldkey, unban_coldkey
 from queries.competition import (
     replace_competition_allocations,
+    replace_competition_metadata,
     replace_competition_policy,
     update_competition_state,
 )
@@ -76,6 +78,17 @@ def validate_hotkey(miner_hotkey: str) -> None:
         Keypair(ss58_address=miner_hotkey)
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid hotkey SS58 address") from None
+
+
+@router.put("/competitions/{set_id}", response_model=CompetitionAdminSnapshot)
+async def put_competition_metadata(
+    set_id: int,
+    request: CompetitionMetadataUpdateRequest,
+    actor: Annotated[str, Depends(require_coldkey_ban_admin)],
+) -> CompetitionAdminSnapshot:
+    snapshot = await replace_competition_metadata(set_id=set_id, target=request, actor=actor)
+    clear_all_ttl_caches()
+    return snapshot
 
 
 @router.put("/competitions/{set_id}/state", response_model=CompetitionAdminSnapshot)

--- a/db/models/competition.py
+++ b/db/models/competition.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 from uuid import UUID
 
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -16,6 +16,12 @@ class Competition(Base, CreatedAtMixin):
 
     set_id: Mapped[int] = mapped_column(sa.Integer, primary_key=True)
     name: Mapped[Optional[str]] = mapped_column(sa.Text)
+    description: Mapped[Optional[str]] = mapped_column(sa.Text)
+    links: Mapped[list[str]] = mapped_column(
+        ARRAY(sa.Text),
+        nullable=False,
+        server_default=sa.text("'{}'::text[]"),
+    )
     start_date: Mapped[Optional[datetime]] = mapped_column(sa.TIMESTAMP(timezone=True))
     submissions_closed_at: Mapped[Optional[datetime]] = mapped_column(sa.TIMESTAMP(timezone=True))
     is_paused: Mapped[bool] = mapped_column(sa.Boolean, nullable=False, server_default=sa.text("false"))
@@ -95,6 +101,10 @@ class Competition(Base, CreatedAtMixin):
             "AND incentive_time_multiplier_scale_hours "
             "NOT IN ('NaN'::numeric, 'Infinity'::numeric, '-Infinity'::numeric)))",
             name="ck_competitions_incentive_durations",
+        ),
+        sa.CheckConstraint(
+            "coalesce(competitions_links_are_nonblank(links), true)",
+            name="ck_competitions_links_nonblank",
         ),
         sa.CheckConstraint(
             "end_date IS NULL OR start_date IS NULL OR end_date >= start_date",

--- a/db/models/competition.py
+++ b/db/models/competition.py
@@ -135,7 +135,7 @@ class CompetitionAdminEvent(Base, CreatedAtMixin):
 
     __table_args__ = (
         sa.CheckConstraint(
-            "operation IN ('state', 'policy', 'allocation')",
+            "operation IN ('state', 'policy', 'allocation', 'metadata')",
             name="ck_competition_admin_events_operation",
         ),
         sa.CheckConstraint(

--- a/models/competition.py
+++ b/models/competition.py
@@ -132,7 +132,7 @@ class CompetitionStateUpdateRequest(BaseModel):
     started: StrictBool
     submissions_closed: StrictBool
     is_paused: StrictBool
-    emissions_end_at: AwareDatetime | None
+    emissions_end_at: Annotated[AwareDatetime | None, Field(strict=False)]
     ended: StrictBool
     reason: AdminReason
 

--- a/models/competition.py
+++ b/models/competition.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Annotated, Literal
 
 from pydantic import (
+    AnyHttpUrl,
     AwareDatetime,
     BaseModel,
     ConfigDict,
@@ -146,6 +147,29 @@ class CompetitionPolicyUpdateRequest(CompetitionPolicy):
     reason: AdminReason
 
 
+class CompetitionMetadata(BaseModel):
+    """Editorial fields that carry no lifecycle or scoring meaning."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    name: Annotated[str, StringConstraints(strict=True, strip_whitespace=True, min_length=1, max_length=200)] | None
+    description: (
+        Annotated[str, StringConstraints(strict=True, strip_whitespace=True, min_length=1, max_length=5000)] | None
+    )
+    links: Annotated[list[AnyHttpUrl], Field(max_length=20)]
+
+    @model_validator(mode="after")
+    def reject_duplicate_links(self) -> CompetitionMetadata:
+        rendered = [str(link) for link in self.links]
+        if len(rendered) != len(set(rendered)):
+            raise ValueError("links must not contain duplicates")
+        return self
+
+
+class CompetitionMetadataUpdateRequest(CompetitionMetadata):
+    reason: AdminReason
+
+
 RawEmissionWeight = Annotated[
     Decimal,
     Field(ge=Decimal("0"), le=Decimal("1"), allow_inf_nan=False),
@@ -177,6 +201,9 @@ class CompetitionAllocationUpdateRequest(BaseModel):
 
 class CompetitionAdminSnapshot(BaseModel):
     set_id: int
+    name: str | None
+    description: str | None
+    links: list[str]
     state: CompetitionState
     started: bool
     start_date: datetime | None

--- a/models/competition.py
+++ b/models/competition.py
@@ -29,6 +29,8 @@ class CompetitionState(str, Enum):
 class PublicCompetition(BaseModel):
     set_id: int
     name: str | None
+    description: str | None
+    links: list[str]
     state: CompetitionState
     accepting: bool
     processable: bool

--- a/queries/competition.py
+++ b/queries/competition.py
@@ -101,6 +101,8 @@ _PUBLIC_COMPETITION_SELECT = f"""
     SELECT
         competition.set_id,
         competition.name,
+        competition.description,
+        competition.links,
         competition.created_at,
         competition.start_date,
         competition.submissions_closed_at,
@@ -212,6 +214,8 @@ def _public_competition_from_row(row: Mapping[str, object]) -> PublicCompetition
     return PublicCompetition(
         set_id=int(row["set_id"]),
         name=row["name"],
+        description=row["description"],
+        links=list(row["links"] or []),
         state=state,
         accepting=accepting,
         processable=processable,

--- a/queries/competition.py
+++ b/queries/competition.py
@@ -14,6 +14,7 @@ from models.competition import (
     CompetitionAllocation,
     CompetitionAllocationSnapshot,
     CompetitionAllocationUpdateRequest,
+    CompetitionMetadataUpdateRequest,
     CompetitionPolicy,
     CompetitionPolicyUpdateRequest,
     CompetitionState,
@@ -72,6 +73,9 @@ _COMPETITION_CONTEXT_SELECT = """
 _ADMIN_COMPETITION_SELECT = """
     SELECT
         set_id,
+        name,
+        description,
+        links,
         start_date,
         submissions_closed_at,
         is_paused,
@@ -173,6 +177,9 @@ def _admin_snapshot_from_row(row: Mapping[str, object]) -> CompetitionAdminSnaps
     end_date = row["end_date"]
     return CompetitionAdminSnapshot(
         set_id=int(row["set_id"]),
+        name=row["name"],
+        description=row["description"],
+        links=list(row["links"] or []),
         state=derive_competition_state(
             start_date=start_date,
             submissions_closed_at=submissions_closed_at,
@@ -524,7 +531,7 @@ async def initialize_current_competition_policy(conn: DatabaseConnection) -> Com
 async def _insert_competition_admin_event(
     conn: DatabaseConnection,
     *,
-    operation: Literal["state", "policy", "allocation"],
+    operation: Literal["state", "policy", "allocation", "metadata"],
     actor: str,
     reason: str,
     before_state: dict[str, object],
@@ -818,6 +825,71 @@ async def replace_competition_policy(
         await _insert_competition_admin_event(
             conn,
             operation="policy",
+            actor=actor,
+            reason=target.reason,
+            before_state=_audit_snapshot(before),
+            after_state=_audit_snapshot(after),
+        )
+        return after
+
+
+@db_operation
+async def replace_competition_metadata(
+    conn: DatabaseConnection,
+    *,
+    set_id: int,
+    target: CompetitionMetadataUpdateRequest,
+    actor: str,
+) -> CompetitionAdminSnapshot:
+    """Replace the editorial fields wholesale.
+
+    Metadata carries no lifecycle or scoring meaning, so unlike state transitions this
+    stays available after a competition has ended.
+    """
+    name = target.name
+    description = target.description
+    links = [str(link) for link in target.links]
+    async with conn.conn.transaction():
+        row = await conn.fetchrow(
+            f"""
+            {_ADMIN_COMPETITION_SELECT}
+            WHERE set_id = $1
+            FOR UPDATE
+            """,
+            set_id,
+        )
+        if row is None:
+            raise CompetitionNotFoundError(set_id)
+
+        before = _admin_snapshot_from_row(row)
+        if (before.name, before.description, before.links) == (name, description, links):
+            return before
+
+        await conn.execute(
+            """
+            UPDATE competitions
+            SET
+                name = $2,
+                description = $3,
+                links = $4
+            WHERE set_id = $1
+            """,
+            set_id,
+            name,
+            description,
+            links,
+        )
+        updated_row = await conn.fetchrow(
+            f"""
+            {_ADMIN_COMPETITION_SELECT}
+            WHERE set_id = $1
+            """,
+            set_id,
+        )
+        after = _admin_snapshot_from_row(updated_row)
+        await _insert_competition_admin_event(
+            conn,
+            operation="metadata",
             actor=actor,
             reason=target.reason,
             before_state=_audit_snapshot(before),

--- a/tests/api/test_admin_competitions.py
+++ b/tests/api/test_admin_competitions.py
@@ -20,6 +20,7 @@ from models.competition import (
     CompetitionAdminSnapshot,
     CompetitionAllocationSnapshot,
     CompetitionAllocationUpdateRequest,
+    CompetitionMetadataUpdateRequest,
     CompetitionPolicy,
     CompetitionPolicyUpdateRequest,
     CompetitionState,
@@ -27,6 +28,7 @@ from models.competition import (
 )
 from queries.competition import (
     replace_competition_allocations,
+    replace_competition_metadata,
     replace_competition_policy,
     update_competition_state,
 )
@@ -121,17 +123,21 @@ async def _seed_competition(
     )
 
 
+_TRUNCATE = "TRUNCATE competition_admin_events, evaluation_sets, competitions, agents RESTART IDENTITY CASCADE"
+
+
 @pytest.fixture
-async def clean_competitions(postgres_db):
+async def db(postgres_db):
+    """A pooled connection for seeding and asserting."""
     async with _db.pool.acquire() as conn:
-        await conn.execute(
-            "TRUNCATE competition_admin_events, evaluation_sets, competitions, agents RESTART IDENTITY CASCADE"
-        )
+        yield conn
+
+
+@pytest.fixture
+async def clean_competitions(db):
+    await db.execute(_TRUNCATE)
     yield
-    async with _db.pool.acquire() as conn:
-        await conn.execute(
-            "TRUNCATE competition_admin_events, evaluation_sets, competitions, agents RESTART IDENTITY CASCADE"
-        )
+    await db.execute(_TRUNCATE)
 
 
 def _state_request(**overrides) -> CompetitionStateUpdateRequest:
@@ -152,9 +158,19 @@ def _policy_request(**overrides) -> CompetitionPolicyUpdateRequest:
     return CompetitionPolicyUpdateRequest(**_policy(**overrides).model_dump(), reason=reason)
 
 
-async def test_open_initializes_defaults_once_and_exact_retry_is_not_audited(clean_competitions) -> None:
-    async with _db.pool.acquire() as conn:
-        await _seed_competition(conn, set_id=10)
+def _metadata_request(**overrides) -> CompetitionMetadataUpdateRequest:
+    values = {
+        "name": "Competition One",
+        "description": "A long-form blurb.",
+        "links": ["https://docs.example.com/"],
+        "reason": "operator metadata update",
+    }
+    values.update(overrides)
+    return CompetitionMetadataUpdateRequest(**values)
+
+
+async def test_open_initializes_defaults_once_and_exact_retry_is_not_audited(clean_competitions, db) -> None:
+    await _seed_competition(db, set_id=10)
 
     opened = await update_competition_state(
         set_id=10,
@@ -171,8 +187,7 @@ async def test_open_initializes_defaults_once_and_exact_retry_is_not_audited(cle
     assert opened.start_date is not None
     assert opened.policy == competition_queries.current_competition_policy_defaults(10)
     assert retried == opened
-    async with _db.pool.acquire() as conn:
-        events = await conn.fetch("SELECT * FROM competition_admin_events")
+    events = await db.fetch("SELECT * FROM competition_admin_events")
     assert len(events) == 1
     assert events[0]["operation"] == "state"
     assert events[0]["actor"] == ADMIN_ACTOR
@@ -184,27 +199,26 @@ async def test_open_initializes_defaults_once_and_exact_retry_is_not_audited(cle
 @pytest.mark.parametrize("missing_group", ["screener_1", "screener_2", "validator"])
 async def test_open_requires_a_nonempty_task_in_every_pipeline_group(
     clean_competitions,
+    db,
     missing_group: str,
 ) -> None:
     groups = tuple(group for group in ("screener_1", "screener_2", "validator") if group != missing_group)
-    async with _db.pool.acquire() as conn:
-        await _seed_competition(conn, set_id=11, groups=groups)
+    await _seed_competition(db, set_id=11, groups=groups)
 
     with pytest.raises(CompetitionAdminConflictError, match=missing_group):
         await update_competition_state(set_id=11, target=_state_request(), actor=ADMIN_ACTOR)
 
-    async with _db.pool.acquire() as conn:
-        row = await conn.fetchrow("SELECT start_date, scoring_mode FROM competitions WHERE set_id = 11")
-        assert dict(row) == {"start_date": None, "scoring_mode": None}
-        assert await conn.fetchval("SELECT count(*) FROM competition_admin_events") == 0
+    row = await db.fetchrow("SELECT start_date, scoring_mode FROM competitions WHERE set_id = 11")
+    assert dict(row) == {"start_date": None, "scoring_mode": None}
+    assert await db.fetchval("SELECT count(*) FROM competition_admin_events") == 0
 
 
 async def test_open_preserves_explicit_policy_and_cutoff_can_be_reopened_or_amended(
     clean_competitions,
+    db,
 ) -> None:
     explicit_policy = _policy(screener_1_threshold=0.87)
-    async with _db.pool.acquire() as conn:
-        await _seed_competition(conn, set_id=12, policy=explicit_policy)
+    await _seed_competition(db, set_id=12, policy=explicit_policy)
 
     opened = await update_competition_state(set_id=12, target=_state_request(), actor=ADMIN_ACTOR)
     cutoff = datetime.now(timezone.utc) + timedelta(hours=1)
@@ -220,17 +234,16 @@ async def test_open_preserves_explicit_policy_and_cutoff_can_be_reopened_or_amen
     )
     old_close = datetime.now(timezone.utc) - timedelta(days=2)
     old_cutoff = old_close + timedelta(hours=1)
-    async with _db.pool.acquire() as conn:
-        await conn.execute(
-            """
-            UPDATE competitions
-            SET submissions_closed_at = $2, emissions_end_at = $3
-            WHERE set_id = $1
-            """,
-            12,
-            old_close,
-            old_cutoff,
-        )
+    await db.execute(
+        """
+        UPDATE competitions
+        SET submissions_closed_at = $2, emissions_end_at = $3
+        WHERE set_id = $1
+        """,
+        12,
+        old_close,
+        old_cutoff,
+    )
     amended = await update_competition_state(
         set_id=12,
         target=_state_request(
@@ -252,10 +265,9 @@ async def test_open_preserves_explicit_policy_and_cutoff_can_be_reopened_or_amen
     assert amended.emissions_end_at == amended.submissions_closed_at == old_close
 
 
-async def test_draft_cancellation_direct_end_and_terminal_state(clean_competitions) -> None:
-    async with _db.pool.acquire() as conn:
-        await _seed_competition(conn, set_id=20, groups=())
-        await _seed_competition(conn, set_id=21, started=True, policy=_policy())
+async def test_draft_cancellation_direct_end_and_terminal_state(clean_competitions, db) -> None:
+    await _seed_competition(db, set_id=20, groups=())
+    await _seed_competition(db, set_id=21, started=True, policy=_policy())
 
     cancelled = await update_competition_state(
         set_id=20,
@@ -279,8 +291,7 @@ async def test_draft_cancellation_direct_end_and_terminal_state(clean_competitio
             actor=ADMIN_ACTOR,
         )
     with pytest.raises(CompetitionAdminConflictError, match="return to draft"):
-        async with _db.pool.acquire() as conn:
-            await _seed_competition(conn, set_id=22, started=True, policy=_policy())
+        await _seed_competition(db, set_id=22, started=True, policy=_policy())
         await update_competition_state(
             set_id=22,
             target=_state_request(started=False),
@@ -288,9 +299,8 @@ async def test_draft_cancellation_direct_end_and_terminal_state(clean_competitio
         )
 
 
-async def test_policy_replace_is_complete_editable_after_end_and_noop_safe(clean_competitions) -> None:
-    async with _db.pool.acquire() as conn:
-        await _seed_competition(conn, set_id=30, started=True, ended=True, policy=_policy())
+async def test_policy_replace_is_complete_editable_after_end_and_noop_safe(clean_competitions, db) -> None:
+    await _seed_competition(db, set_id=30, started=True, ended=True, policy=_policy())
 
     changed = await replace_competition_policy(
         set_id=30,
@@ -310,18 +320,16 @@ async def test_policy_replace_is_complete_editable_after_end_and_noop_safe(clean
     assert changed.policy.screener_1_threshold == pytest.approx(0.87)
     assert changed.policy.hardcoding_policy_version == "hardcoding-v2"
     assert retried == changed
-    async with _db.pool.acquire() as conn:
-        events = await conn.fetch("SELECT operation, before_state, after_state FROM competition_admin_events")
+    events = await db.fetch("SELECT operation, before_state, after_state FROM competition_admin_events")
     assert len(events) == 1
     assert events[0]["operation"] == "policy"
     assert json.loads(events[0]["before_state"])["policy"]["screener_1_threshold"] == 0.41
     assert json.loads(events[0]["after_state"])["policy"]["screener_1_threshold"] == 0.87
 
 
-async def test_allocation_replaces_complete_sorted_vector_and_reports_owner_remainder(clean_competitions) -> None:
-    async with _db.pool.acquire() as conn:
-        await _seed_competition(conn, set_id=40, started=True, ended=True, policy=_policy())
-        await _seed_competition(conn, set_id=10, policy=None)
+async def test_allocation_replaces_complete_sorted_vector_and_reports_owner_remainder(clean_competitions, db) -> None:
+    await _seed_competition(db, set_id=40, started=True, ended=True, policy=_policy())
+    await _seed_competition(db, set_id=10, policy=None)
 
     request = CompetitionAllocationUpdateRequest.model_validate(
         {
@@ -344,9 +352,8 @@ async def test_allocation_replaces_complete_sorted_vector_and_reports_owner_rema
     ]
     assert changed.owner_emission_weight == Decimal("0.60")
     assert retried == changed
-    async with _db.pool.acquire() as conn:
-        rows = await conn.fetch("SELECT set_id, raw_emission_weight FROM competitions ORDER BY set_id")
-        events = await conn.fetch("SELECT before_state, after_state FROM competition_admin_events")
+    rows = await db.fetch("SELECT set_id, raw_emission_weight FROM competitions ORDER BY set_id")
+    events = await db.fetch("SELECT before_state, after_state FROM competition_admin_events")
     assert [(row["set_id"], row["raw_emission_weight"]) for row in rows] == [
         (10, Decimal("0.25")),
         (40, Decimal("0.15")),
@@ -357,10 +364,9 @@ async def test_allocation_replaces_complete_sorted_vector_and_reports_owner_rema
     assert after_state["owner_emission_weight"] == "0.60"
 
 
-async def test_allocation_rejects_stale_catalog_and_model_rejects_invalid_vectors(clean_competitions) -> None:
-    async with _db.pool.acquire() as conn:
-        await _seed_competition(conn, set_id=50)
-        await _seed_competition(conn, set_id=51)
+async def test_allocation_rejects_stale_catalog_and_model_rejects_invalid_vectors(clean_competitions, db) -> None:
+    await _seed_competition(db, set_id=50)
+    await _seed_competition(db, set_id=51)
 
     incomplete = CompetitionAllocationUpdateRequest(
         allocations=[{"set_id": 50, "raw_emission_weight": Decimal("0.5")}],
@@ -395,9 +401,8 @@ def test_allocation_snapshot_preserves_a_microscopic_owner_remainder() -> None:
     assert snapshot.owner_emission_weight == Decimal("1e-400")
 
 
-async def test_audit_failure_rolls_back_state_change(clean_competitions, monkeypatch) -> None:
-    async with _db.pool.acquire() as conn:
-        await _seed_competition(conn, set_id=60, started=True, policy=_policy())
+async def test_audit_failure_rolls_back_state_change(clean_competitions, db, monkeypatch) -> None:
+    await _seed_competition(db, set_id=60, started=True, policy=_policy())
 
     async def fail_audit(*args, **kwargs):
         raise RuntimeError("audit unavailable")
@@ -410,14 +415,16 @@ async def test_audit_failure_rolls_back_state_change(clean_competitions, monkeyp
             actor=ADMIN_ACTOR,
         )
 
-    async with _db.pool.acquire() as conn:
-        assert await conn.fetchval("SELECT is_paused FROM competitions WHERE set_id = 60") is False
-        assert await conn.fetchval("SELECT count(*) FROM competition_admin_events") == 0
+    assert await db.fetchval("SELECT is_paused FROM competitions WHERE set_id = 60") is False
+    assert await db.fetchval("SELECT count(*) FROM competition_admin_events") == 0
 
 
 def _sample_snapshot() -> CompetitionAdminSnapshot:
     return CompetitionAdminSnapshot(
         set_id=1,
+        name="Sample",
+        description=None,
+        links=[],
         state=CompetitionState.open,
         started=True,
         start_date=datetime.now(timezone.utc),
@@ -435,6 +442,7 @@ def _sample_snapshot() -> CompetitionAdminSnapshot:
 def _make_client(monkeypatch) -> TestClient:
     monkeypatch.setattr(admin_endpoint, "update_competition_state", AsyncMock(return_value=_sample_snapshot()))
     monkeypatch.setattr(admin_endpoint, "replace_competition_policy", AsyncMock(return_value=_sample_snapshot()))
+    monkeypatch.setattr(admin_endpoint, "replace_competition_metadata", AsyncMock(return_value=_sample_snapshot()))
     monkeypatch.setattr(
         admin_endpoint,
         "replace_competition_allocations",
@@ -456,9 +464,11 @@ def test_competition_routes_require_configured_admin_bearer(monkeypatch) -> None
     state_payload = _state_request().model_dump(mode="json")
     policy_payload = _policy_request().model_dump(mode="json")
     allocation_payload = {"allocations": [], "reason": "set vector"}
+    metadata_payload = _metadata_request().model_dump(mode="json")
     routes = [
         ("/admin/competitions/1/state", state_payload),
         ("/admin/competitions/1/policy", policy_payload),
+        ("/admin/competitions/1", metadata_payload),
         ("/admin/competition-allocations", allocation_payload),
     ]
     for path, payload in routes:
@@ -484,6 +494,12 @@ def test_competition_routes_accept_strict_complete_bodies_and_fixed_actor(monkey
     assert client.put("/admin/competitions/1/policy", json=policy_payload, headers=auth).status_code == 200
     assert admin_endpoint.replace_competition_policy.await_args.kwargs["actor"] == ADMIN_ACTOR
 
+    metadata_payload = _metadata_request(reason="  retitle  ").model_dump(mode="json")
+    assert client.put("/admin/competitions/1", json=metadata_payload, headers=auth).status_code == 200
+    metadata_call = admin_endpoint.replace_competition_metadata.await_args
+    assert metadata_call.kwargs["actor"] == ADMIN_ACTOR
+    assert metadata_call.kwargs["target"].reason == "retitle"
+
     allocation_payload = {
         "allocations": [{"set_id": 1, "raw_emission_weight": 0.25}],
         "reason": "set vector",
@@ -494,6 +510,9 @@ def test_competition_routes_accept_strict_complete_bodies_and_fixed_actor(monkey
     for path, payload in (
         ("/admin/competitions/1/state", {**state_payload, "unexpected": True}),
         ("/admin/competitions/1/policy", {**policy_payload, "unexpected": True}),
+        ("/admin/competitions/1", {**metadata_payload, "unexpected": True}),
+        ("/admin/competitions/1", {**metadata_payload, "links": ["javascript:alert(1)"]}),
+        ("/admin/competitions/1", {**metadata_payload, "links": ["not a url"]}),
         ("/admin/competition-allocations", {**allocation_payload, "unexpected": True}),
     ):
         assert client.put(path, json=payload, headers=auth).status_code == 422
@@ -617,3 +636,72 @@ async def test_competition_admin_success_refreshes_cached_values_but_failure_kee
         assert reads == 2
     finally:
         clear_all_ttl_caches()
+
+
+async def test_metadata_round_trips_and_is_audited(clean_competitions, db) -> None:
+    await _seed_competition(db, set_id=70, started=True, policy=_policy())
+
+    updated = await replace_competition_metadata(
+        set_id=70,
+        target=_metadata_request(
+            name="Renamed",
+            description="Fresh blurb.",
+            links=["https://a.example.com/", "https://b.example.com/docs"],
+        ),
+        actor=ADMIN_ACTOR,
+    )
+    assert updated.name == "Renamed"
+    assert updated.description == "Fresh blurb."
+    assert updated.links == ["https://a.example.com/", "https://b.example.com/docs"]
+
+    stored = await db.fetchrow("SELECT name, description, links FROM competitions WHERE set_id = 70")
+    events = await db.fetch("SELECT operation, actor, reason, before_state, after_state FROM competition_admin_events")
+
+    assert stored["name"] == "Renamed"
+    assert stored["description"] == "Fresh blurb."
+    assert stored["links"] == ["https://a.example.com/", "https://b.example.com/docs"]
+
+    assert len(events) == 1
+    assert events[0]["operation"] == "metadata"
+    assert events[0]["actor"] == ADMIN_ACTOR
+    assert events[0]["reason"] == "operator metadata update"
+    assert json.loads(events[0]["before_state"])["name"] is None
+    assert json.loads(events[0]["after_state"])["name"] == "Renamed"
+
+
+async def test_metadata_clears_fields_and_skips_audit_on_exact_retry(clean_competitions, db) -> None:
+    await _seed_competition(db, set_id=71, started=True, policy=_policy())
+
+    request = _metadata_request(name="Titled", description="Blurb.", links=["https://a.example.com/"])
+    await replace_competition_metadata(set_id=71, target=request, actor=ADMIN_ACTOR)
+    retried = await replace_competition_metadata(set_id=71, target=request, actor=ADMIN_ACTOR)
+    assert retried.name == "Titled"
+
+    cleared = await replace_competition_metadata(
+        set_id=71,
+        target=_metadata_request(name=None, description=None, links=[]),
+        actor=ADMIN_ACTOR,
+    )
+    assert (cleared.name, cleared.description, cleared.links) == (None, None, [])
+
+    operations = await db.fetch("SELECT operation FROM competition_admin_events ORDER BY created_at, event_id")
+
+    # The identical retry is a no-op, so only the initial write and the clear are audited.
+    assert [row["operation"] for row in operations] == ["metadata", "metadata"]
+
+
+async def test_metadata_stays_editable_after_a_competition_ends(clean_competitions, db) -> None:
+    await _seed_competition(db, set_id=72, started=True, ended=True, policy=_policy())
+
+    updated = await replace_competition_metadata(
+        set_id=72,
+        target=_metadata_request(name="Corrected after the fact"),
+        actor=ADMIN_ACTOR,
+    )
+    assert updated.ended is True
+    assert updated.name == "Corrected after the fact"
+
+
+async def test_metadata_update_on_missing_competition_raises_not_found(clean_competitions) -> None:
+    with pytest.raises(CompetitionNotFoundError):
+        await replace_competition_metadata(set_id=999, target=_metadata_request(), actor=ADMIN_ACTOR)

--- a/tests/api/test_public_competitions.py
+++ b/tests/api/test_public_competitions.py
@@ -39,6 +39,8 @@ async def _insert_competition(
     *,
     set_id: int,
     name: str | None,
+    description: str | None = None,
+    links: list[str] | None = None,
     start_date: datetime | None = NOW,
     submissions_closed_at: datetime | None = None,
     is_paused: bool = False,
@@ -53,6 +55,8 @@ async def _insert_competition(
         INSERT INTO competitions (
             set_id,
             name,
+            description,
+            links,
             created_at,
             start_date,
             submissions_closed_at,
@@ -74,12 +78,14 @@ async def _insert_competition(
             incentive_reward_half_life_hours,
             incentive_time_multiplier_scale_hours
         ) VALUES (
-            $1, $2, $3, $4, $5, $6, $7, $8, $9,
-            $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11,
+            $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24
         )
         """,
         set_id,
         name,
+        description,
+        links if links is not None else [],
         NOW - timedelta(days=set_id),
         start_date,
         submissions_closed_at,
@@ -237,6 +243,8 @@ async def test_public_openapi_is_lean_and_explicit_detail_hides_drafts() -> None
     assert set(public_schema) == {
         "set_id",
         "name",
+        "description",
+        "links",
         "state",
         "accepting",
         "processable",
@@ -249,3 +257,32 @@ async def test_public_openapi_is_lean_and_explicit_detail_hides_drafts() -> None
         "raw_emission_weight",
     }
     assert "policy" not in public_schema
+
+
+async def test_catalog_and_detail_expose_description_and_links() -> None:
+    links = ["https://docs.example.com", "https://x.com/example"]
+    async with _db.pool.acquire() as conn:
+        await _insert_competition(
+            conn,
+            set_id=1,
+            name="Documented",
+            description="A long-form blurb about this competition.",
+            links=links,
+        )
+
+    detail = await competitions_endpoint.competition_detail(1)
+    assert detail.description == "A long-form blurb about this competition."
+    assert detail.links == links
+
+    [listed] = await competitions_endpoint.competition_catalog()
+    assert listed.description == "A long-form blurb about this competition."
+    assert listed.links == links
+
+
+async def test_metadata_defaults_to_null_description_and_empty_links() -> None:
+    async with _db.pool.acquire() as conn:
+        await _insert_competition(conn, set_id=1, name="Bare")
+
+    detail = await competitions_endpoint.competition_detail(1)
+    assert detail.description is None
+    assert detail.links == []


### PR DESCRIPTION
## Summary

This PR adds two new fields to the `Competition` table:
- `description`: string field that stores a brief description of the Competition
- `links`: array of strings that stores a list of competition related links
 
These fields were added to the response schema of the `GET /competitions` and `GET /competitions/{set_id}`.

A new endpoint was also added `PUT /admin/competitions/{set_id}` that allows an admin User to update the Competition metadata: name, description and links. This operation, just like the other admin competition operations, gets stored on the `CompetitionAdminEvent` audit table.

New tests were added to validate the changes.