### PR TITLE
feat: prevent cluster-autoscaler from draining a screener mid-evaluation

### DIFF
--- a/tests/utils/test_k8s_safe_to_evict.py
+++ b/tests/utils/test_k8s_safe_to_evict.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from kubernetes.client.rest import ApiException
+
+from utils.k8s import SAFE_TO_EVICT_ANNOTATION, set_screener_safe_to_evict
+
+
+def _kubernetes_env(monkeypatch, *, pod_name: str = "ridges-screener-1-0", namespace: str = "ridges-prod"):
+    monkeypatch.setenv("RIDGES_ENVIRONMENT_TYPE", "kubernetes")
+    monkeypatch.setenv("MY_POD_NAME", pod_name)
+    monkeypatch.setenv("K8S_NAMESPACE", namespace)
+
+
+def test_patches_false_and_true(monkeypatch):
+    _kubernetes_env(monkeypatch)
+    api = MagicMock()
+    monkeypatch.setattr("utils.k8s._get_core_api", lambda: api)
+
+    set_screener_safe_to_evict(False)
+    set_screener_safe_to_evict(True)
+
+    assert api.patch_namespaced_pod.call_count == 2
+    false_call, true_call = api.patch_namespaced_pod.call_args_list
+    assert false_call.kwargs["name"] == "ridges-screener-1-0"
+    assert false_call.kwargs["namespace"] == "ridges-prod"
+    assert false_call.kwargs["body"] == {
+        "metadata": {"annotations": {SAFE_TO_EVICT_ANNOTATION: "false"}}
+    }
+    assert true_call.kwargs["body"] == {
+        "metadata": {"annotations": {SAFE_TO_EVICT_ANNOTATION: "true"}}
+    }
+
+
+def test_noop_without_pod_name(monkeypatch):
+    monkeypatch.setenv("RIDGES_ENVIRONMENT_TYPE", "kubernetes")
+    monkeypatch.delenv("MY_POD_NAME", raising=False)
+    api = MagicMock()
+    monkeypatch.setattr("utils.k8s._get_core_api", lambda: api)
+
+    set_screener_safe_to_evict(False)
+
+    api.patch_namespaced_pod.assert_not_called()
+
+
+def test_noop_outside_kubernetes(monkeypatch):
+    monkeypatch.setenv("RIDGES_ENVIRONMENT_TYPE", "docker")
+    monkeypatch.setenv("MY_POD_NAME", "ridges-screener-1-0")
+    api = MagicMock()
+    monkeypatch.setattr("utils.k8s._get_core_api", lambda: api)
+
+    set_screener_safe_to_evict(False)
+
+    api.patch_namespaced_pod.assert_not_called()
+
+
+def test_api_exception_does_not_raise(monkeypatch):
+    _kubernetes_env(monkeypatch)
+    api = MagicMock()
+    api.patch_namespaced_pod.side_effect = ApiException(status=403, reason="Forbidden")
+    monkeypatch.setattr("utils.k8s._get_core_api", lambda: api)
+
+    set_screener_safe_to_evict(False)
+
+    api.patch_namespaced_pod.assert_called_once()

--- a/tests/utils/test_k8s_safe_to_evict.py
+++ b/tests/utils/test_k8s_safe_to_evict.py
@@ -25,12 +25,8 @@ def test_patches_false_and_true(monkeypatch):
     false_call, true_call = api.patch_namespaced_pod.call_args_list
     assert false_call.kwargs["name"] == "ridges-screener-1-0"
     assert false_call.kwargs["namespace"] == "ridges-prod"
-    assert false_call.kwargs["body"] == {
-        "metadata": {"annotations": {SAFE_TO_EVICT_ANNOTATION: "false"}}
-    }
-    assert true_call.kwargs["body"] == {
-        "metadata": {"annotations": {SAFE_TO_EVICT_ANNOTATION: "true"}}
-    }
+    assert false_call.kwargs["body"] == {"metadata": {"annotations": {SAFE_TO_EVICT_ANNOTATION: "false"}}}
+    assert true_call.kwargs["body"] == {"metadata": {"annotations": {SAFE_TO_EVICT_ANNOTATION: "true"}}}
 
 
 def test_noop_without_pod_name(monkeypatch):

--- a/utils/k8s.py
+++ b/utils/k8s.py
@@ -12,6 +12,8 @@ from kubernetes.client.rest import ApiException
 
 logger = logging.getLogger(__name__)
 
+SAFE_TO_EVICT_ANNOTATION = "cluster-autoscaler.kubernetes.io/safe-to-evict"
+
 _core_api: Optional[k8s_client.CoreV1Api] = None
 
 
@@ -24,6 +26,38 @@ def _get_core_api() -> k8s_client.CoreV1Api:
             k8s_config.load_kube_config(context=os.getenv("K8S_CONTEXT"))
         _core_api = k8s_client.CoreV1Api()
     return _core_api
+
+
+def set_screener_safe_to_evict(safe: bool) -> None:
+    """Patch this pod's cluster-autoscaler safe-to-evict annotation.
+
+    Best-effort: never raises. No-op outside Kubernetes or when MY_POD_NAME
+    is unset. A false value blocks CA drain of this node so owner-ref GC
+    cannot delete in-flight eval pods.
+    """
+    if os.getenv("RIDGES_ENVIRONMENT_TYPE") != "kubernetes":
+        return
+    pod_name = os.getenv("MY_POD_NAME")
+    if not pod_name:
+        return
+
+    namespace = os.getenv("K8S_NAMESPACE", "ridges")
+    value = "true" if safe else "false"
+    body = {"metadata": {"annotations": {SAFE_TO_EVICT_ANNOTATION: value}}}
+    try:
+        api = _get_core_api()
+        api.patch_namespaced_pod(name=pod_name, namespace=namespace, body=body)
+    except Exception as exc:
+        logger.warning(
+            "Failed to set %s=%s on pod %s/%s: %s",
+            SAFE_TO_EVICT_ANNOTATION,
+            value,
+            namespace,
+            pod_name,
+            exc,
+        )
+        return
+    logger.info("Set %s=%s on pod %s/%s", SAFE_TO_EVICT_ANNOTATION, value, namespace, pod_name)
 
 
 def get_num_k8s_eval_pods() -> int:

--- a/validator/main.py
+++ b/validator/main.py
@@ -151,9 +151,10 @@ async def _run_startup_tasks() -> None:
         import validator.healthz as healthz
 
         _healthz_task = asyncio.create_task(healthz.serve(get_session_id=lambda: session_id))
-        from utils.k8s import cleanup_harbor_k8s_resources
+        from utils.k8s import cleanup_harbor_k8s_resources, set_screener_safe_to_evict
 
         await asyncio.to_thread(cleanup_harbor_k8s_resources)
+        await asyncio.to_thread(set_screener_safe_to_evict, True)
 
     asyncio.get_running_loop().add_signal_handler(
         signal.SIGTERM,
@@ -783,20 +784,25 @@ async def _run_evaluation(request_evaluation_response: ValidatorRequestEvaluatio
     _log_received_evaluation(request_evaluation_response)
     logger.info("Starting evaluation...")
 
-    await _pre_build_missing_images(request_evaluation_response)
-
-    tasks = _create_evaluation_run_tasks(request_evaluation_response)
-
-    poll_task = asyncio.create_task(
-        _poll_evaluation_cancellation(
-            request_evaluation_response.evaluation_id,
-            request_evaluation_response.agent_id,
-            cancellation_event,
-            cancellation_reason,
-        )
-    )
-
     try:
+        if config.RIDGES_ENVIRONMENT_TYPE == "kubernetes":
+            from utils.k8s import set_screener_safe_to_evict
+
+            await asyncio.to_thread(set_screener_safe_to_evict, False)
+
+        await _pre_build_missing_images(request_evaluation_response)
+
+        tasks = _create_evaluation_run_tasks(request_evaluation_response)
+
+        poll_task = asyncio.create_task(
+            _poll_evaluation_cancellation(
+                request_evaluation_response.evaluation_id,
+                request_evaluation_response.agent_id,
+                cancellation_event,
+                cancellation_reason,
+            )
+        )
+
         run_tasks_task, cancellation_wait_task = await _wait_for_runs_or_cancellation(tasks, cancellation_event)
 
         if cancellation_event.is_set():
@@ -823,9 +829,10 @@ async def _run_evaluation(request_evaluation_response: ValidatorRequestEvaluatio
         if config.RIDGES_ENVIRONMENT_TYPE == "docker":
             await asyncio.to_thread(prune_docker_disk_resources)
         elif config.RIDGES_ENVIRONMENT_TYPE == "kubernetes":
-            from utils.k8s import cleanup_completed_k8s_eval_pods
+            from utils.k8s import cleanup_completed_k8s_eval_pods, set_screener_safe_to_evict
 
             await asyncio.to_thread(cleanup_completed_k8s_eval_pods)
+            await asyncio.to_thread(set_screener_safe_to_evict, True)
 
 
 # Main loop


### PR DESCRIPTION
## Summary
- Patch `cluster-autoscaler.kubernetes.io/safe-to-evict` to `false` before pre-build and back to `true` when the evaluation batch finishes
- Reset to `true` on Kubernetes startup so a container restart cannot leave the annotation stuck
- Best-effort helper: no-op outside k8s / without `MY_POD_NAME`; never fail the eval on API errors