### PR TITLE
fix: stop sharing one BuildKit cache tag and drop tee on runtime logs

### DIFF
--- a/k8s/local/registry.yaml
+++ b/k8s/local/registry.yaml
@@ -101,6 +101,10 @@ spec:
               value: "test"
             - name: AWS_SECRET_ACCESS_KEY
               value: "test"
+            - name: GOMEMLIMIT
+              value: "768MiB"
+            - name: GOGC
+              value: "50"
           volumeMounts:
             - name: config
               mountPath: /etc/zot/config.json
@@ -113,16 +117,23 @@ spec:
             # Zot temp metadata directory (required even with S3 backend).
             - name: tmp
               mountPath: /tmp/zot
+          startupProbe:
+            tcpSocket:
+              port: 5000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 60
           readinessProbe:
             tcpSocket:
               port: 5000
-            initialDelaySeconds: 5
             periodSeconds: 10
+            timeoutSeconds: 5
           livenessProbe:
             tcpSocket:
               port: 5000
-            initialDelaySeconds: 15
             periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
           resources:
             requests:
               cpu: "100m"

--- a/ridges_harbor/agents.py
+++ b/ridges_harbor/agents.py
@@ -319,7 +319,7 @@ class RidgesMinerAgent(BaseInstalledAgent):
                 f"--instruction {shlex.quote(self._env_instruction_path)} "
                 f"--patch {shlex.quote(self._env_raw_patch_path)} "
                 f"--runtime {shlex.quote(self._env_runtime_payload_path)} "
-                f"2>&1 | tee {shlex.quote(self._env_runtime_log_path)}"
+                f"> {shlex.quote(self._env_runtime_log_path)} 2>&1"
             )
 
             await self._exec_with_log(

--- a/ridges_harbor/k8s_environment.py
+++ b/ridges_harbor/k8s_environment.py
@@ -1925,6 +1925,7 @@ def _build_job_body(
     """
     tier = max(0, min(tier, len(BUILD_MEMORY_TIERS) - 1))
     memory_request, memory_limit = BUILD_MEMORY_TIERS[tier]
+    _ = registry
 
     fetch_script = (
         'curl -sSfL "$PRESIGNED_URL" -o /tmp/task.tar.gz && '
@@ -1966,14 +1967,9 @@ def _build_job_body(
         ),
     )
 
-    cache_ref = f"{registry}/cache"
     output_opt = f"type=image,name={image_ref},push=true"
-    export_cache_opt = f"type=registry,ref={cache_ref},mode=max"
-    import_cache_opt = f"type=registry,ref={cache_ref}"
     if registry_insecure:
         output_opt += ",registry.insecure=true"
-        export_cache_opt += ",registry.insecure=true"
-        import_cache_opt += ",registry.insecure=true"
 
     buildkit_args = [
         "build",
@@ -1982,8 +1978,6 @@ def _build_job_body(
         f"--local=dockerfile=/workspace/{context_name}",
         f"--opt=filename={dockerfile_name}",
         f"--output={output_opt}",
-        f"--export-cache={export_cache_opt}",
-        f"--import-cache={import_cache_opt}",
     ]
 
     buildkit_volume_mounts = [

--- a/tests/ridges_harbor/test_k8s_native_separate.py
+++ b/tests/ridges_harbor/test_k8s_native_separate.py
@@ -541,6 +541,7 @@ def test_agent_build_job_uses_environment_context() -> None:
     assert "--local=context=/workspace/environment" in build_args
     assert "--local=dockerfile=/workspace/environment" in build_args
     assert "--opt=filename=Dockerfile" in build_args
+    assert not any(arg.startswith("--export-cache=") or arg.startswith("--import-cache=") for arg in build_args)
 
 
 def test_sidecar_build_job_uses_named_dockerfile() -> None:

--- a/tests/ridges_harbor/test_runner.py
+++ b/tests/ridges_harbor/test_runner.py
@@ -670,6 +670,8 @@ async def test_run_ensures_git_baseline_before_runtime_and_patch_apply(tmp_path:
     assert calls[0]["error_type"] is MinerRuntimeError
     assert calls[1]["include_output_body"] is False
     assert miner._env_raw_patch_path in str(calls[1]["command"])
+    assert "tee " not in str(calls[1]["command"])
+    assert f"> {miner._env_runtime_log_path} 2>&1" in str(calls[1]["command"])
     assert miner._env_raw_patch_path in str(calls[2]["command"])
     assert miner._env_patch_path not in str(calls[2]["command"])
     assert miner._env_raw_patch_path in str(calls[3]["command"])


### PR DESCRIPTION
## Summary
- Remove `--import-cache` / `--export-cache` on the shared `registry/cache` ref. Per-task image tags and `_registry_image_exists()` still skip rebuilds.
- Replace `tee` with `> runtime.log 2>&1` so Harbor still gets the log after agent SIGKILL.
